### PR TITLE
Add text grid field and enhance grid previews

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -73,12 +73,35 @@
                 <button class="btn btn-sm btn-outline-secondary" @onclick="SortOptions">Sort A-Z</button>
             </div>
         }
+        else if (Field.FieldType == "grid_text")
+        {
+            <div class="mt-3">
+                <label class="form-label">Grid Columns</label>
+                <div @ref="gridColsRef">
+                    @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
+                    {
+                        <div class="d-flex align-items-center mb-1">
+                            <input class="form-control flex-grow-1" @bind="Field.GridColumns[idx]" />
+                            <div class="btn-group btn-group-sm ms-1">
+                                <button class="btn btn-outline-secondary" @onclick="() => MoveColumnUp(idx)"><span class="material-icons">arrow_upward</span></button>
+                                <button class="btn btn-outline-secondary" @onclick="() => MoveColumnDown(idx)"><span class="material-icons">arrow_downward</span></button>
+                            </div>
+                            <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => Field.GridColumns.RemoveAt(idx)">×</button>
+                        </div>
+                    }
+                </div>
+                <div class="d-flex gap-2 mt-1">
+                    <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
+                    <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
+                </div>
+            </div>
+        }
         else if (Field.FieldType.StartsWith("grid"))
         {
             <div class="row mt-3">
                 <div class="col-md-6">
                     <label class="form-label">Grid Rows</label>
-                    <div>
+                    <div @ref="gridRowsRef">
                         @foreach (var (row, idx) in Field.GridRows.Select((r, i) => (r, i)))
                         {
                             <div class="d-flex align-items-center mb-1">
@@ -91,13 +114,14 @@
                             </div>
                         }
                     </div>
-                    <div class="mt-1">
+                    <div class="d-flex gap-2 mt-1">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="AddRow">+ Add Row</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortRows">Sort A-Z</button>
                     </div>
                 </div>
                 <div class="col-md-6">
                     <label class="form-label">Grid Columns</label>
-                    <div>
+                    <div @ref="gridColsRef">
                         @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
                         {
                             <div class="d-flex align-items-center mb-1">
@@ -110,7 +134,8 @@
                             </div>
                         }
                     </div>
-                    <div class="mt-1">
+                    <div class="d-flex gap-2 mt-1">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                     </div>
                 </div>
@@ -166,6 +191,8 @@
     public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
 
     ElementReference optionsRef;
+    ElementReference gridRowsRef;
+    ElementReference gridColsRef;
     ElementReference imageContainerRef;
     InputFile? imageInput;
     bool imageResizeInit;
@@ -188,6 +215,7 @@
         "scale" => "Linear Scale",
         "grid_radio" => "Choice Grid",
         "grid_checkbox" => "Checkbox Grid",
+        "grid_text" => "Text Grid",
         "title" => "Title",
         "section" => "Section",
         "file" => "Upload File",
@@ -273,6 +301,20 @@
         Field.OptionItems.Add(string.Empty);
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("focusLastInput", optionsRef);
+    }
+
+    async Task AddRow()
+    {
+        Field.GridRows.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("focusLastInput", gridRowsRef);
+    }
+
+    async Task AddColumn()
+    {
+        Field.GridColumns.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("focusLastInput", gridColsRef);
     }
 
     async Task PromptImageUpload()

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -125,6 +125,26 @@
                                 </tbody>
                             </table>
                             break;
+                        case "grid_text":
+                            <table class="table table-bordered table-sm">
+                                <thead>
+                                    <tr>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <th>@col</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <td><input class="form-control" /></td>
+                                        }
+                                    </tr>
+                                </tbody>
+                            </table>
+                            break;
                         case "file":
                             <input type="file" class="form-control" />
                             break;

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -60,6 +60,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                 <div class="draggable-field" draggable="true" data-type="scale"><span class="material-icons me-1">linear_scale</span> Linear Scale</div>
                 <div class="draggable-field" draggable="true" data-type="grid_radio"><span class="material-icons me-1">grid_on</span> Choice Grid</div>
                 <div class="draggable-field" draggable="true" data-type="grid_checkbox"><span class="material-icons me-1">grid_view</span> Checkbox Grid</div>
+                <div class="draggable-field" draggable="true" data-type="grid_text"><span class="material-icons me-1">table_chart</span> Text Grid</div>
                 <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
                 <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
                 <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
@@ -614,6 +615,7 @@ List<object> BuildFieldPayload()
                 var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                 var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                 string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
+                    : f.FieldType == "grid_text" && colsList.Count > 0 ? JsonSerializer.Serialize(new { Columns = colsList })
                     : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
                     : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
                     : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
@@ -710,7 +712,18 @@ List<object> BuildFieldPayload()
                 {
                     try
                     {
-                        field.OptionItems = JsonSerializer.Deserialize<List<string>>(f.OptionsJson) ?? new();
+                        var optsDoc = JsonDocument.Parse(f.OptionsJson);
+                        if (optsDoc.RootElement.ValueKind == JsonValueKind.Array)
+                        {
+                            field.OptionItems = optsDoc.RootElement.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                        }
+                        else if (optsDoc.RootElement.ValueKind == JsonValueKind.Object)
+                        {
+                            if (optsDoc.RootElement.TryGetProperty("Rows", out var rowsEl) && rowsEl.ValueKind == JsonValueKind.Array)
+                                field.GridRows = rowsEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                            if (optsDoc.RootElement.TryGetProperty("Columns", out var colsEl) && colsEl.ValueKind == JsonValueKind.Array)
+                                field.GridColumns = colsEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                        }
                     }
                     catch { }
                 }
@@ -775,6 +788,16 @@ List<object> BuildFieldPayload()
                     Severity = NotificationSeverity.Warning,
                     Summary = "Options Required",
                     Detail = $"Add at least one row and column for '{f.Label}'."
+                });
+                return;
+            }
+            if (f.FieldType == "grid_text" && !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one column for '{f.Label}'."
                 });
                 return;
             }

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -158,6 +158,75 @@ else
                         }
                         break;
 
+                    case "grid_radio":
+                    case "grid_checkbox":
+                        var gridOpts = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}");
+                        var gridRows = gridOpts?.Rows ?? new List<string>();
+                        var gridCols = gridOpts?.Columns ?? new List<string>();
+                        <table class="table table-bordered table-sm">
+                            <thead>
+                                <tr>
+                                    <th></th>
+                                    @foreach (var col in gridCols)
+                                    {
+                                        <th>@col</th>
+                                    }
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var row in gridRows)
+                                {
+                                    <tr>
+                                        <td><strong>@row</strong></td>
+                                        @foreach (var col in gridCols)
+                                        {
+                                            <td>
+                                                @if (fld.FieldType == "grid_radio")
+                                                {
+                                                    <input type="radio" name="@($"grid-{fld.Key}-{row}")" value="@col" checked="@(GetGridRadioValue(fld.Key, row) == col)" @onchange="e => OnGridRadioChanged(fld.Key, row, col)" />
+                                                }
+                                                else
+                                                {
+                                                    <input type="checkbox" checked="@IsGridCheckboxChecked(fld.Key, row, col)" @onchange="e => OnGridCheckboxChanged(fld.Key, row, col, e)" />
+                                                }
+                                            </td>
+                                        }
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        break;
+
+                    case "grid_text":
+                        var textOpts = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}");
+                        var textCols = textOpts?.Columns ?? new List<string>();
+                        var textRows = GetGridTextRows(fld.Key, textCols);
+                        <table class="table table-bordered table-sm">
+                            <thead>
+                                <tr>
+                                    @foreach (var col in textCols)
+                                    {
+                                        <th>@col</th>
+                                    }
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var (row, rIdx) in textRows.Select((r, i) => (r, i)))
+                                {
+                                    <tr>
+                                        @foreach (var col in textCols)
+                                        {
+                                            <td><input class="form-control" value="@row[col]" @onchange="e => OnGridTextChanged(fld.Key, rIdx, col, e)" /></td>
+                                        }
+                                        <td><button type="button" class="btn btn-sm btn-danger" @onclick="() => RemoveGridTextRow(fld.Key, rIdx)">Delete</button></td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="() => AddGridTextRow(fld.Key, textCols)">+ Add Row</button>
+                        break;
+
                     case "file":
                         <InputFile OnChange="e => OnFileUploadChanged(fld.Key, e)" />
                         @if (responseData.ContainsKey(fld.Key))
@@ -298,6 +367,9 @@ else
                 responseData[fld.Key] = fld.FieldType switch
                 {
                     "checkbox" => new List<string>(),
+                    "grid_radio" => new Dictionary<string, string>(),
+                    "grid_checkbox" => new Dictionary<string, List<string>>(),
+                    "grid_text" => new List<Dictionary<string, string>>(),
                     "number" => (object?)null,
                     "date" => (object?)null,
                     "time" => (object?)null,
@@ -409,6 +481,81 @@ else
             responseData[key] = dt;
         else
             responseData[key] = null;
+    }
+
+    string? GetGridRadioValue(string key, string row)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is Dictionary<string, string> dict && dict.TryGetValue(row, out var sel))
+            return sel;
+        return null;
+    }
+
+    void OnGridRadioChanged(string key, string row, string col)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not Dictionary<string, string> dict)
+        {
+            dict = new();
+            responseData[key] = dict;
+        }
+        dict[row] = col;
+    }
+
+    bool IsGridCheckboxChecked(string key, string row, string col)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is Dictionary<string, List<string>> dict && dict.TryGetValue(row, out var list))
+            return list.Contains(col);
+        return false;
+    }
+
+    void OnGridCheckboxChanged(string key, string row, string col, ChangeEventArgs e)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not Dictionary<string, List<string>> dict)
+        {
+            dict = new();
+            responseData[key] = dict;
+        }
+        if (!dict.TryGetValue(row, out var list))
+        {
+            list = new();
+            dict[row] = list;
+        }
+        if ((bool?)e.Value == true)
+        {
+            if (!list.Contains(col))
+                list.Add(col);
+        }
+        else
+        {
+            list.Remove(col);
+        }
+    }
+
+    List<Dictionary<string, string>> GetGridTextRows(string key, List<string> cols)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not List<Dictionary<string, string>> rows)
+        {
+            rows = new List<Dictionary<string, string>> { cols.ToDictionary(c => c, c => string.Empty) };
+            responseData[key] = rows;
+        }
+        return rows;
+    }
+
+    void AddGridTextRow(string key, List<string> cols)
+    {
+        var rows = GetGridTextRows(key, cols);
+        rows.Add(cols.ToDictionary(c => c, c => string.Empty));
+    }
+
+    void RemoveGridTextRow(string key, int index)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is List<Dictionary<string, string>> rows && index >= 0 && index < rows.Count)
+            rows.RemoveAt(index);
+    }
+
+    void OnGridTextChanged(string key, int rowIndex, string col, ChangeEventArgs e)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is List<Dictionary<string, string>> rows && rowIndex >= 0 && rowIndex < rows.Count)
+            rows[rowIndex][col] = e.Value?.ToString() ?? string.Empty;
     }
 
     void OnCheckboxChanged(string key, string option, ChangeEventArgs e)
@@ -536,11 +683,20 @@ else
         if (value == null) return true;
         if (value is string s) return string.IsNullOrWhiteSpace(s);
         if (value is IEnumerable<string> list) return !list.Any();
+        if (value is Dictionary<string, string> dr) return dr.Count == 0 || dr.Values.All(string.IsNullOrWhiteSpace);
+        if (value is Dictionary<string, List<string>> dc) return dc.Count == 0 || dc.Values.All(v => v == null || !v.Any());
+        if (value is List<Dictionary<string, string>> tl) return tl.Count == 0 || tl.All(r => r.Values.All(string.IsNullOrWhiteSpace));
         return false;
     }
 
     private class FileUploadResult
     {
         public string filePath { get; set; }
+    }
+
+    private class GridOptions
+    {
+        public List<string>? Rows { get; set; }
+        public List<string>? Columns { get; set; }
     }
 }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -15,18 +15,10 @@
 
 <NavigationLock OnBeforeInternalNavigation="PromptDraft" ConfirmExternalNavigation="true" />
 
-<h2 class="mb-2">Form Builder</h2>
-<p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
-
-@if (isPreviewMode)
-{
-    <div class="mb-3">
-        <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Building</button>
-    </div>
-}
-
 @if (!isPreviewMode)
 {
+    <h2 class="mb-2">Form Builder</h2>
+    <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
     <div class="row">
         <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
             <div class="mb-3 d-flex align-items-center gap-2">
@@ -53,6 +45,7 @@
                 <div class="draggable-field" draggable="true" data-type="scale"><span class="material-icons me-1">linear_scale</span> Linear Scale</div>
                 <div class="draggable-field" draggable="true" data-type="grid_radio"><span class="material-icons me-1">grid_on</span> Choice Grid</div>
                 <div class="draggable-field" draggable="true" data-type="grid_checkbox"><span class="material-icons me-1">grid_view</span> Checkbox Grid</div>
+                <div class="draggable-field" draggable="true" data-type="grid_text"><span class="material-icons me-1">table_chart</span> Text Grid</div>
                 <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
                 <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
                 <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
@@ -170,16 +163,12 @@
 }
 else
 {
-    <div class="row">
-        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
-            <div class="mb-3">
-                <h5 class="mb-0">Toolbox</h5>
-            </div>
+    <div class="preview-overlay">
+        <div class="position-fixed top-0 end-0 m-3">
+            <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Building</button>
         </div>
-        <div class="col-md-9">
-            <div class="card p-3 shadow-sm">
-                <LivePreview Sections="sections" FormName="@formName" />
-            </div>
+        <div class="p-4">
+            <LivePreview Sections="sections" FormName="@formName" />
         </div>
     </div>
 }
@@ -559,6 +548,7 @@ else
                     var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                     var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                     string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
+                        : f.FieldType == "grid_text" && colsList.Count > 0 ? JsonSerializer.Serialize(new { Columns = colsList })
                         : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
                         : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
                         : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
@@ -635,6 +625,17 @@ else
                     Severity = NotificationSeverity.Warning,
                     Summary = "Options Required",
                     Detail = $"Add at least one row and column for '{f.Label}'."
+                });
+                return;
+            }
+
+            if (f.FieldType == "grid_text" && !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one column for '{f.Label}'."
                 });
                 return;
             }

--- a/Client/Pages/DynamicForms/Index.razor.css
+++ b/Client/Pages/DynamicForms/Index.razor.css
@@ -1,0 +1,10 @@
+.preview-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    overflow: auto;
+    background-color: #fff;
+    z-index: 1050;
+}

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -721,6 +721,7 @@ namespace DynamicFormsApp.Server.Services
             "textarea" => "NVARCHAR(MAX)",
             "grid_radio" => "NVARCHAR(MAX)",    // JSON object
             "grid_checkbox" => "NVARCHAR(MAX)", // JSON object
+            "grid_text" => "NVARCHAR(MAX)",     // JSON array of rows
             "scale" => "INT",
             _ => "NVARCHAR(MAX)"
         };


### PR DESCRIPTION
## Summary
- show form preview full screen on `/NewForm`
- allow rows and columns to be added to grid fields and add new **Text Grid** option
- render grid fields (choice, checkbox, text) in tabular format when filling a form

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a878187df88329818e4cef9b1a01e2