### PR TITLE
Add toolbox previews and default row for text grid

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -73,12 +73,35 @@
                 <button class="btn btn-sm btn-outline-secondary" @onclick="SortOptions">Sort A-Z</button>
             </div>
         }
+        else if (Field.FieldType == "grid_text")
+        {
+            <div class="mt-3">
+                <label class="form-label">Grid Columns</label>
+                <div @ref="gridColsRef">
+                    @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
+                    {
+                        <div class="d-flex align-items-center mb-1">
+                            <input class="form-control flex-grow-1" @bind="Field.GridColumns[idx]" />
+                            <div class="btn-group btn-group-sm ms-1">
+                                <button class="btn btn-outline-secondary" @onclick="() => MoveColumnUp(idx)"><span class="material-icons">arrow_upward</span></button>
+                                <button class="btn btn-outline-secondary" @onclick="() => MoveColumnDown(idx)"><span class="material-icons">arrow_downward</span></button>
+                            </div>
+                            <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => Field.GridColumns.RemoveAt(idx)">×</button>
+                        </div>
+                    }
+                </div>
+                <div class="d-flex gap-2 mt-1">
+                    <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
+                    <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
+                </div>
+            </div>
+        }
         else if (Field.FieldType.StartsWith("grid"))
         {
             <div class="row mt-3">
                 <div class="col-md-6">
                     <label class="form-label">Grid Rows</label>
-                    <div>
+                    <div @ref="gridRowsRef">
                         @foreach (var (row, idx) in Field.GridRows.Select((r, i) => (r, i)))
                         {
                             <div class="d-flex align-items-center mb-1">
@@ -91,13 +114,14 @@
                             </div>
                         }
                     </div>
-                    <div class="mt-1">
+                    <div class="d-flex gap-2 mt-1">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="AddRow">+ Add Row</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortRows">Sort A-Z</button>
                     </div>
                 </div>
                 <div class="col-md-6">
                     <label class="form-label">Grid Columns</label>
-                    <div>
+                    <div @ref="gridColsRef">
                         @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
                         {
                             <div class="d-flex align-items-center mb-1">
@@ -110,7 +134,8 @@
                             </div>
                         }
                     </div>
-                    <div class="mt-1">
+                    <div class="d-flex gap-2 mt-1">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                     </div>
                 </div>
@@ -166,6 +191,8 @@
     public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
 
     ElementReference optionsRef;
+    ElementReference gridRowsRef;
+    ElementReference gridColsRef;
     ElementReference imageContainerRef;
     InputFile? imageInput;
     bool imageResizeInit;
@@ -188,6 +215,7 @@
         "scale" => "Linear Scale",
         "grid_radio" => "Choice Grid",
         "grid_checkbox" => "Checkbox Grid",
+        "grid_text" => "Text Grid",
         "title" => "Title",
         "section" => "Section",
         "file" => "Upload File",
@@ -273,6 +301,20 @@
         Field.OptionItems.Add(string.Empty);
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("focusLastInput", optionsRef);
+    }
+
+    async Task AddRow()
+    {
+        Field.GridRows.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("focusLastInput", gridRowsRef);
+    }
+
+    async Task AddColumn()
+    {
+        Field.GridColumns.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("focusLastInput", gridColsRef);
     }
 
     async Task PromptImageUpload()

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -19,11 +19,15 @@
                 <span class="badge bg-secondary">@GetTypeLabel(Field.FieldType)</span>
             </div>
             <div class="d-flex gap-2">
-                <button class="btn btn-sm btn-outline-secondary" @onclick="() => OnDuplicate.InvokeAsync(Field)">
-                    <span class="material-icons">content_copy</span>
-                </button>
-                <button class="btn btn-sm btn-outline-danger" @onclick="() => OnRemove.InvokeAsync(Field)">
-                    <span class="material-icons">delete</span>
+                @if (Field.FieldType is "radio" or "checkbox" or "dropdown" or 
+                    "grid_radio" or "grid_checkbox" or "grid_text")
+                {
+                    <button class="btn btn-sm btn-outline-primary" title="Save as component" @onclick="() => OnSaveComponent.InvokeAsync(Field)">
+                        <span class="material-icons">save</span>
+                    </button>
+                }
+                <button class="btn btn-outline-danger btn-sm p-1" @onclick="() => OnRemove.InvokeAsync(Field)">
+                    <span class="material-icons" style="font-size:16px;line-height:1">delete</span>
                 </button>
             </div>
         </div>
@@ -186,7 +190,7 @@
 @code {
     [Parameter] public DesignerField Field { get; set; }
     [Parameter] public EventCallback<DesignerField> OnRemove { get; set; }
-    [Parameter] public EventCallback<DesignerField> OnDuplicate { get; set; }
+    [Parameter] public EventCallback<DesignerField> OnSaveComponent { get; set; }
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
 

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -9,17 +9,17 @@
 
 <div class="card mb-3 shadow-sm field-card" @attributes="AdditionalAttributes">
     <div class="card-body">
-        <div class="d-flex justify-content-between mb-2">
-            <div class="d-flex align-items-center gap-2">
+        <div class="d-flex flex-wrap align-items-start mb-2">
+            <div class="d-flex align-items-center gap-2 flex-grow-1">
                 <span class="drag-handle text-muted"><span class="material-icons fs-4">drag_indicator</span></span>
                 @if (Field.FieldType != "image" && Field.FieldType != "statictext")
                 {
-                    <input class="form-control form-control-sm" placeholder="Field label" @bind="Field.Label" />
+                    <input class="form-control form-control-sm flex-grow-1" placeholder="Field label" @bind="Field.Label" />
                 }
                 <span class="badge bg-secondary">@GetTypeLabel(Field.FieldType)</span>
             </div>
-            <div class="d-flex gap-2">
-                @if (Field.FieldType is "radio" or "checkbox" or "dropdown" or 
+            <div class="d-flex gap-2 ms-auto mt-2 mt-sm-0">
+                @if (Field.FieldType is "radio" or "checkbox" or "dropdown" or
                     "grid_radio" or "grid_checkbox" or "grid_text")
                 {
                     <button class="btn btn-sm btn-outline-primary" title="Save as component" @onclick="() => OnSaveComponent.InvokeAsync(Field)">

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -72,7 +72,7 @@
                     </div>
                 }
             </div>
-            <div class="d-flex gap-2 mt-1">
+            <div class="d-flex flex-wrap gap-2 mt-1">
                 <button class="btn btn-sm btn-outline-primary" @onclick="AddOption">+ Add Option</button>
                 <button class="btn btn-sm btn-outline-secondary" @onclick="SortOptions">Sort A-Z</button>
             </div>
@@ -94,7 +94,7 @@
                         </div>
                     }
                 </div>
-                <div class="d-flex gap-2 mt-1">
+                <div class="d-flex flex-wrap gap-2 mt-1">
                     <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
                     <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                 </div>
@@ -102,7 +102,7 @@
         }
         else if (Field.FieldType.StartsWith("grid"))
         {
-            <div class="row mt-3">
+            <div class="row g-2 mt-3">
                 <div class="col-md-6">
                     <label class="form-label">Grid Rows</label>
                     <div @ref="gridRowsRef">
@@ -118,7 +118,7 @@
                             </div>
                         }
                     </div>
-                    <div class="d-flex gap-2 mt-1">
+                    <div class="d-flex flex-wrap gap-2 mt-1">
                         <button class="btn btn-sm btn-outline-primary" @onclick="AddRow">+ Add Row</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortRows">Sort A-Z</button>
                     </div>
@@ -138,7 +138,7 @@
                             </div>
                         }
                     </div>
-                    <div class="d-flex gap-2 mt-1">
+                    <div class="d-flex flex-wrap gap-2 mt-1">
                         <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                     </div>

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -125,6 +125,26 @@
                                 </tbody>
                             </table>
                             break;
+                        case "grid_text":
+                            <table class="table table-bordered table-sm">
+                                <thead>
+                                    <tr>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <th>@col</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <td><input class="form-control" /></td>
+                                        }
+                                    </tr>
+                                </tbody>
+                            </table>
+                            break;
                         case "file":
                             <input type="file" class="form-control" />
                             break;

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -60,6 +60,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                 <div class="draggable-field" draggable="true" data-type="scale"><span class="material-icons me-1">linear_scale</span> Linear Scale</div>
                 <div class="draggable-field" draggable="true" data-type="grid_radio"><span class="material-icons me-1">grid_on</span> Choice Grid</div>
                 <div class="draggable-field" draggable="true" data-type="grid_checkbox"><span class="material-icons me-1">grid_view</span> Checkbox Grid</div>
+                <div class="draggable-field" draggable="true" data-type="grid_text"><span class="material-icons me-1">table_chart</span> Text Grid</div>
                 <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
                 <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
                 <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
@@ -614,6 +615,7 @@ List<object> BuildFieldPayload()
                 var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                 var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                 string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
+                    : f.FieldType == "grid_text" && colsList.Count > 0 ? JsonSerializer.Serialize(new { Columns = colsList })
                     : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
                     : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
                     : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
@@ -710,7 +712,18 @@ List<object> BuildFieldPayload()
                 {
                     try
                     {
-                        field.OptionItems = JsonSerializer.Deserialize<List<string>>(f.OptionsJson) ?? new();
+                        var optsDoc = JsonDocument.Parse(f.OptionsJson);
+                        if (optsDoc.RootElement.ValueKind == JsonValueKind.Array)
+                        {
+                            field.OptionItems = optsDoc.RootElement.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                        }
+                        else if (optsDoc.RootElement.ValueKind == JsonValueKind.Object)
+                        {
+                            if (optsDoc.RootElement.TryGetProperty("Rows", out var rowsEl) && rowsEl.ValueKind == JsonValueKind.Array)
+                                field.GridRows = rowsEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                            if (optsDoc.RootElement.TryGetProperty("Columns", out var colsEl) && colsEl.ValueKind == JsonValueKind.Array)
+                                field.GridColumns = colsEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                        }
                     }
                     catch { }
                 }
@@ -775,6 +788,16 @@ List<object> BuildFieldPayload()
                     Severity = NotificationSeverity.Warning,
                     Summary = "Options Required",
                     Detail = $"Add at least one row and column for '{f.Label}'."
+                });
+                return;
+            }
+            if (f.FieldType == "grid_text" && !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one column for '{f.Label}'."
                 });
                 return;
             }

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -3,7 +3,9 @@
 @using System.Net
 @using System.Text.Json
 @using System.Collections.Generic
+@using System.Linq
 @using DynamicFormsApp.Client.Components
+@using DynamicFormsApp.Client.Services
 @using DynamicFormsApp.Shared
 @using DynamicFormsApp.Shared.Models
 @inject IJSRuntime JS
@@ -11,6 +13,7 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 @inject IUserService UserService
+@inject ComponentServiceProxy ComponentService
 
 @implements IDisposable
 
@@ -65,6 +68,24 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                 <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
                 <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
             </div>
+            @if (customComponents.Any())
+            {
+                <h6 class="mt-3">Saved Components</h6>
+                <div class="d-flex flex-wrap gap-2">
+                    @foreach (var comp in customComponents)
+                    {
+                        <div class="draggable-field position-relative" draggable="true" data-type="component-@comp.Id">
+                            <span class="material-icons me-1">view_module</span> @comp.Name
+                            @if (comp.CreatedBy == currentUser?.UserName)
+                            {
+                                <button class="btn btn-link btn-sm text-danger position-absolute top-0 end-0" title="Delete" @onclick="() => DeleteComponent(comp.Id)">
+                                    <span class="material-icons" style="font-size:16px">delete</span>
+                                </button>
+                            }
+                        </div>
+                    }
+                </div>
+            }
             <h6 class="mt-3">User Fields</h6>
             <div class="d-flex flex-wrap gap-2">
                 <div class="draggable-field" draggable="true" data-type="user"><span class="material-icons me-1">person</span> User Dropdown</div>
@@ -151,7 +172,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                                                 <div class="col-12 col-md-@(12 / (sections[secIndex].Rows[rowIndex].Fields.Count == 0 ? 1 : sections[secIndex].Rows[rowIndex].Fields.Count))" data-id="@i" @key="sections[secIndex].Rows[rowIndex].Fields[i]">
                                                     <FieldEditor Field="sections[secIndex].Rows[rowIndex].Fields[i]"
                                                                  OnRemove="async f => await RemoveField(secIndex, rowIndex, f)"
-                                                                 OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
+                                                                 OnSaveComponent="async f => await SaveComponent(f)" />
                                                 </div>
                                             }
                                         </div>
@@ -217,6 +238,7 @@ else
     private DeletedFormInfo? unavailableInfo;
     private List<string> deptOptions = new();
     private List<string> locOptions = new();
+    private List<CustomComponent> customComponents = new();
     private bool restrictionAlertShown = false;
 
     private Stack<List<DesignerSection>> undoStack = new();
@@ -265,6 +287,7 @@ else
             notificationEmail = currentUser?.Email ?? string.Empty;
             deptOptions = await UserService.GetDepartments();
             locOptions = await UserService.GetLocations();
+            customComponents = await ComponentService.GetForDepartment(currentUser?.Department ?? string.Empty);
 
             var resp = await Http.GetAsync($"api/forms/{FormId}");
             if (!resp.IsSuccessStatusCode)
@@ -302,7 +325,9 @@ else
             {
                 await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
             }
+            await JS.InvokeAsync<IJSObjectReference>("import", $"/js/dragdrop-wrapper.js?v={AppInfo.Version}");
             await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
+            await JS.InvokeVoidAsync("initToolboxPreview");
         }
     }
 
@@ -406,28 +431,58 @@ public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSecti
     }
 }
 
-    DesignerField CreateField(string fieldType) => new DesignerField
+    DesignerField CreateField(string fieldType)
     {
-        FieldType = fieldType,
-        Key = fieldType switch
+        if (fieldType.StartsWith("component-") && int.TryParse(fieldType.Substring("component-".Length), out var id))
         {
-            "user" => "select a user",
-            "department" => "department",
-            "location" => "location",
-            _ => string.Empty
-        },
-        Label = fieldType switch
+            var comp = customComponents.FirstOrDefault(c => c.Id == id)?.Field;
+            if (comp != null)
+            {
+                return new DesignerField
+                {
+                    FieldType = comp.FieldType,
+                    Key = comp.Key,
+                    Label = comp.Label,
+                    Instructions = comp.Instructions,
+                    Placeholder = comp.Placeholder,
+                    CharLimit = comp.CharLimit,
+                    MinCharLimit = comp.MinCharLimit,
+                    IsRequired = comp.IsRequired,
+                    ImageUrl = comp.ImageUrl,
+                    ImageWidth = comp.ImageWidth,
+                    ImageHeight = comp.ImageHeight,
+                    OptionItems = new List<string>(comp.OptionItems),
+                    GridRows = new List<string>(comp.GridRows),
+                    GridColumns = new List<string>(comp.GridColumns),
+                    ScaleMin = comp.ScaleMin,
+                    ScaleMax = comp.ScaleMax
+                };
+            }
+        }
+
+        return new DesignerField
         {
-            "user" => "Select a user",
-            "department" => "Department",
-            "location" => "Location",
-            "statictext" => "Text",
-            _ => string.Empty
-        },
-        Placeholder = fieldType == "text" ? "Short answer" :
-                      fieldType == "textarea" ? "Paragraph" :
-                      fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
-    };
+            FieldType = fieldType,
+            Key = fieldType switch
+            {
+                "user" => "select a user",
+                "department" => "department",
+                "location" => "location",
+                _ => string.Empty
+            },
+            Label = fieldType switch
+            {
+                "user" => "Select a user",
+                "department" => "Department",
+                "location" => "Location",
+                "statictext" => "Text",
+                _ => string.Empty
+            },
+            Placeholder = fieldType == "text" ? "Short answer" :
+                          fieldType == "textarea" ? "Paragraph" :
+                          fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
+        };
+    }
 
     async Task RemoveField(int section, int row, DesignerField field)
     {
@@ -451,41 +506,27 @@ public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSecti
         await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task DuplicateField(int section, int row, DesignerField field)
+    async Task SaveComponent(DesignerField field)
     {
-        PushUndo();
-        var copy = new DesignerField
+        if (currentUser == null) return;
+        var comp = await ComponentService.Save(field.Label, field, currentUser.Department ?? string.Empty, currentUser.UserName);
+        if (comp != null)
         {
-            Key = field.Key,
-            Label = field.Label,
-            FieldType = field.FieldType,
-            Placeholder = field.Placeholder,
-            CharLimit = field.CharLimit,
-            MinCharLimit = field.MinCharLimit,
-            IsRequired = field.IsRequired,
-            OptionItems = new List<string>(field.OptionItems),
-            GridColumns = new List<string>(field.GridColumns),
-            GridRows = new List<string>(field.GridRows),
-            ScaleMin = field.ScaleMin,
-            ScaleMax = field.ScaleMax,
-            ImageUrl = field.ImageUrl,
-            ImageWidth = field.ImageWidth,
-            ImageHeight = field.ImageHeight
-        };
-        var list = sections[section].Rows[row].Fields;
-        if (list.Count >= 4)
-        {
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Warning,
-                Summary = "Column limit reached",
-                Detail = "A row can contain at most four columns."
-            });
-            return;
+            customComponents.Add(comp);
+            StateHasChanged();
         }
+    }
 
-        list.Insert(list.IndexOf(field) + 1, copy);
-        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
+    async Task DeleteComponent(int id)
+    {
+        if (currentUser == null) return;
+        await ComponentService.Delete(id, currentUser.UserName);
+        var match = customComponents.FirstOrDefault(c => c.Id == id);
+        if (match != null)
+        {
+            customComponents.Remove(match);
+            StateHasChanged();
+        }
     }
 
 [JSInvokable]

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -513,6 +513,7 @@ public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSecti
         if (comp != null)
         {
             customComponents.Add(comp);
+            await DialogService.Alert("This component will be available across your department.", "Component Saved");
             StateHasChanged();
         }
     }
@@ -520,12 +521,19 @@ public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSecti
     async Task DeleteComponent(int id)
     {
         if (currentUser == null) return;
-        await ComponentService.Delete(id, currentUser.UserName);
-        var match = customComponents.FirstOrDefault(c => c.Id == id);
-        if (match != null)
+        bool? confirm = await DialogService.Confirm(
+            "Are you sure you want to delete this component? It will be removed for everyone in your department.",
+            "Delete Component",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+        if (confirm == true)
         {
-            customComponents.Remove(match);
-            StateHasChanged();
+            await ComponentService.Delete(id, currentUser.UserName);
+            var match = customComponents.FirstOrDefault(c => c.Id == id);
+            if (match != null)
+            {
+                customComponents.Remove(match);
+                StateHasChanged();
+            }
         }
     }
 

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -58,9 +58,6 @@
                            @bind="field.Label" />
                 </div>
                 <div class="btn-group">
-                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => DuplicateField(index)">
-                        <span class="material-icons">content_copy</span>
-                    </button>
                     <button class="btn btn-sm btn-outline-danger" @onclick="() => RemoveField(field)">
                         <span class="material-icons">delete</span>
                     </button>
@@ -166,21 +163,6 @@
     void RemoveField(DesignerField field)
     {
         fields.Remove(field);
-        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
-    }
-
-    void DuplicateField(int index)
-    {
-        var src = fields[index];
-        var copy = new DesignerField
-        {
-            Key = string.Empty,
-            Label = src.Label,
-            FieldType = src.FieldType,
-            Options = src.Options,
-            IsRequired = src.IsRequired
-        };
-        fields.Insert(index + 1, copy);
         JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -158,6 +158,75 @@ else
                         }
                         break;
 
+                    case "grid_radio":
+                    case "grid_checkbox":
+                        var gridOpts = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}");
+                        var gridRows = gridOpts?.Rows ?? new List<string>();
+                        var gridCols = gridOpts?.Columns ?? new List<string>();
+                        <table class="table table-bordered table-sm">
+                            <thead>
+                                <tr>
+                                    <th></th>
+                                    @foreach (var col in gridCols)
+                                    {
+                                        <th>@col</th>
+                                    }
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var row in gridRows)
+                                {
+                                    <tr>
+                                        <td><strong>@row</strong></td>
+                                        @foreach (var col in gridCols)
+                                        {
+                                            <td>
+                                                @if (fld.FieldType == "grid_radio")
+                                                {
+                                                    <input type="radio" name="@($"grid-{fld.Key}-{row}")" value="@col" checked="@(GetGridRadioValue(fld.Key, row) == col)" @onchange="e => OnGridRadioChanged(fld.Key, row, col)" />
+                                                }
+                                                else
+                                                {
+                                                    <input type="checkbox" checked="@IsGridCheckboxChecked(fld.Key, row, col)" @onchange="e => OnGridCheckboxChanged(fld.Key, row, col, e)" />
+                                                }
+                                            </td>
+                                        }
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        break;
+
+                    case "grid_text":
+                        var textOpts = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}");
+                        var textCols = textOpts?.Columns ?? new List<string>();
+                        var textRows = GetGridTextRows(fld.Key, textCols);
+                        <table class="table table-bordered table-sm">
+                            <thead>
+                                <tr>
+                                    @foreach (var col in textCols)
+                                    {
+                                        <th>@col</th>
+                                    }
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var (row, rIdx) in textRows.Select((r, i) => (r, i)))
+                                {
+                                    <tr>
+                                        @foreach (var col in textCols)
+                                        {
+                                            <td><input class="form-control" value="@row[col]" @onchange="e => OnGridTextChanged(fld.Key, rIdx, col, e)" /></td>
+                                        }
+                                        <td><button type="button" class="btn btn-sm btn-danger" @onclick="() => RemoveGridTextRow(fld.Key, rIdx)">Delete</button></td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="() => AddGridTextRow(fld.Key, textCols)">+ Add Row</button>
+                        break;
+
                     case "file":
                         <InputFile OnChange="e => OnFileUploadChanged(fld.Key, e)" />
                         @if (responseData.ContainsKey(fld.Key))
@@ -298,6 +367,9 @@ else
                 responseData[fld.Key] = fld.FieldType switch
                 {
                     "checkbox" => new List<string>(),
+                    "grid_radio" => new Dictionary<string, string>(),
+                    "grid_checkbox" => new Dictionary<string, List<string>>(),
+                    "grid_text" => new List<Dictionary<string, string>>(),
                     "number" => (object?)null,
                     "date" => (object?)null,
                     "time" => (object?)null,
@@ -409,6 +481,83 @@ else
             responseData[key] = dt;
         else
             responseData[key] = null;
+    }
+
+    string? GetGridRadioValue(string key, string row)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is Dictionary<string, string> dict && dict.TryGetValue(row, out var sel))
+            return sel;
+        return null;
+    }
+
+    void OnGridRadioChanged(string key, string row, string col)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not Dictionary<string, string> dict)
+        {
+            dict = new();
+            responseData[key] = dict;
+        }
+        dict[row] = col;
+    }
+
+    bool IsGridCheckboxChecked(string key, string row, string col)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is Dictionary<string, List<string>> dict && dict.TryGetValue(row, out var list))
+            return list.Contains(col);
+        return false;
+    }
+
+    void OnGridCheckboxChanged(string key, string row, string col, ChangeEventArgs e)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not Dictionary<string, List<string>> dict)
+        {
+            dict = new();
+            responseData[key] = dict;
+        }
+        if (!dict.TryGetValue(row, out var list))
+        {
+            list = new();
+            dict[row] = list;
+        }
+        if ((bool?)e.Value == true)
+        {
+            if (!list.Contains(col))
+                list.Add(col);
+        }
+        else
+        {
+            list.Remove(col);
+        }
+    }
+
+    List<Dictionary<string, string>> GetGridTextRows(string key, List<string> cols)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not List<Dictionary<string, string>> rows)
+        {
+            rows = new List<Dictionary<string, string>>();
+            responseData[key] = rows;
+        }
+        if (rows.Count == 0)
+            rows.Add(cols.ToDictionary(c => c, c => string.Empty));
+        return rows;
+    }
+
+    void AddGridTextRow(string key, List<string> cols)
+    {
+        var rows = GetGridTextRows(key, cols);
+        rows.Add(cols.ToDictionary(c => c, c => string.Empty));
+    }
+
+    void RemoveGridTextRow(string key, int index)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is List<Dictionary<string, string>> rows && index >= 0 && index < rows.Count)
+            rows.RemoveAt(index);
+    }
+
+    void OnGridTextChanged(string key, int rowIndex, string col, ChangeEventArgs e)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is List<Dictionary<string, string>> rows && rowIndex >= 0 && rowIndex < rows.Count)
+            rows[rowIndex][col] = e.Value?.ToString() ?? string.Empty;
     }
 
     void OnCheckboxChanged(string key, string option, ChangeEventArgs e)
@@ -536,11 +685,20 @@ else
         if (value == null) return true;
         if (value is string s) return string.IsNullOrWhiteSpace(s);
         if (value is IEnumerable<string> list) return !list.Any();
+        if (value is Dictionary<string, string> dr) return dr.Count == 0 || dr.Values.All(string.IsNullOrWhiteSpace);
+        if (value is Dictionary<string, List<string>> dc) return dc.Count == 0 || dc.Values.All(v => v == null || !v.Any());
+        if (value is List<Dictionary<string, string>> tl) return tl.Count == 0 || tl.All(r => r.Values.All(string.IsNullOrWhiteSpace));
         return false;
     }
 
     private class FileUploadResult
     {
         public string filePath { get; set; }
+    }
+
+    private class GridOptions
+    {
+        public List<string>? Rows { get; set; }
+        public List<string>? Columns { get; set; }
     }
 }

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -5,6 +5,7 @@
 @using System.Linq
 @using DynamicFormsApp.Shared.Models
 @using System.Net
+@using System.Collections.Generic
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
@@ -110,7 +111,7 @@ else
                             <option value="" disabled selected>Select user...</option>
                             @foreach (var u in directoryUsers)
                             {
-                                <option value="@u.DisplayName">@u.DisplayName - @u.Department - @u.Location</option>
+                                <option value="@u.DisplayName">@FormatUserOption(u)</option>
                             }
                         </select>
                         break;
@@ -307,6 +308,14 @@ else
 
     string GetImageStyle(FormField f) =>
         $"max-width:100%;{(f.ImageWidth.HasValue ? $"width:{f.ImageWidth}px;" : string.Empty)}{(f.ImageHeight.HasValue ? $"height:{f.ImageHeight}px;" : string.Empty)}";
+
+    string FormatUserOption(UserModel u)
+    {
+        var parts = new List<string> { u.DisplayName };
+        if (!string.IsNullOrWhiteSpace(u.Department)) parts.Add(u.Department);
+        if (!string.IsNullOrWhiteSpace(u.Location)) parts.Add(u.Location);
+        return string.Join(" - ", parts);
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -1,6 +1,9 @@
 @page "/forms/{FormId:int}/responses"
 @using System.Net.Http.Json
 @using System.Net
+@using System.Text
+@using System.Text.Json
+@using System.Collections.Generic
 @using DynamicFormsApp.Shared.Models
 @using Microsoft.AspNetCore.Components
 @inject HttpClient Http
@@ -53,6 +56,7 @@
                             @foreach (var col in columns)
                             {
                                 <td>
+                                    @{ var field = form.Fields.FirstOrDefault(f => f.Key == col); }
                                     @if (col != "ResponseId" && col != "CreatedAt" && IsFileField(col))
                                     {
                                         var url = row[col]?.ToString();
@@ -75,6 +79,10 @@
                                         {
                                             <span class="text-muted">No file</span>
                                         }
+                                    }
+                                    else if (field?.FieldType == "grid_text")
+                                    {
+                                        @RenderGridText(row[col]?.ToString(), field)
                                     }
                                     else
                                     {
@@ -171,6 +179,45 @@
         return lower.EndsWith(".jpg") || lower.EndsWith(".jpeg") ||
                lower.EndsWith(".png") || lower.EndsWith(".gif") ||
                lower.EndsWith(".bmp") || lower.EndsWith(".webp");
+    }
+
+    private MarkupString RenderGridText(string? val, FormField field)
+    {
+        if (string.IsNullOrWhiteSpace(val)) return (MarkupString)string.Empty;
+        try
+        {
+            var rows = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(val) ?? new();
+            var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
+            var cols = opts?.Columns ?? new List<string>();
+            var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr>");
+            foreach (var c in cols)
+            {
+                sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
+            }
+            sb.Append("</tr></thead><tbody>");
+            foreach (var row in rows)
+            {
+                sb.Append("<tr>");
+                foreach (var c in cols)
+                {
+                    row.TryGetValue(c, out var cell);
+                    sb.Append($"<td>{WebUtility.HtmlEncode(cell)}</td>");
+                }
+                sb.Append("</tr>");
+            }
+            sb.Append("</tbody></table>");
+            return new MarkupString(sb.ToString());
+        }
+        catch
+        {
+            return (MarkupString)val;
+        }
+    }
+
+    private class GridOptions
+    {
+        public List<string>? Rows { get; set; }
+        public List<string>? Columns { get; set; }
     }
 
     private async Task DownloadCsv()

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -317,6 +317,7 @@ else
                 await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
             }
             await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
+            await JS.InvokeVoidAsync("initToolboxPreview");
         }
     }
 

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -574,6 +574,7 @@ else
         if (comp != null)
         {
             customComponents.Add(comp);
+            await DialogService.Alert("This component will be available across your department.", "Component Saved");
             StateHasChanged();
         }
     }
@@ -581,12 +582,19 @@ else
     async Task DeleteComponent(int id)
     {
         if (currentUser == null) return;
-        await ComponentService.Delete(id, currentUser.UserName);
-        var match = customComponents.FirstOrDefault(c => c.Id == id);
-        if (match != null)
+        bool? confirm = await DialogService.Confirm(
+            "Are you sure you want to delete this component? It will be removed for everyone in your department.",
+            "Delete Component",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+        if (confirm == true)
         {
-            customComponents.Remove(match);
-            StateHasChanged();
+            await ComponentService.Delete(id, currentUser.UserName);
+            var match = customComponents.FirstOrDefault(c => c.Id == id);
+            if (match != null)
+            {
+                customComponents.Remove(match);
+                StateHasChanged();
+            }
         }
     }
 

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -15,18 +15,10 @@
 
 <NavigationLock OnBeforeInternalNavigation="PromptDraft" ConfirmExternalNavigation="true" />
 
-<h2 class="mb-2">Form Builder</h2>
-<p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
-
-@if (isPreviewMode)
-{
-    <div class="mb-3">
-        <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Building</button>
-    </div>
-}
-
 @if (!isPreviewMode)
 {
+    <h2 class="mb-2">Form Builder</h2>
+    <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
     <div class="row">
         <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
             <div class="mb-3 d-flex align-items-center gap-2">
@@ -42,26 +34,98 @@
                 </div>
             </div>
             <div class="d-flex flex-wrap gap-2">
-                <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
-                <div class="draggable-field" draggable="true" data-type="textarea"><span class="material-icons me-1">notes</span> Paragraph</div>
-                <div class="draggable-field" draggable="true" data-type="radio"><span class="material-icons me-1">radio_button_checked</span> Multiple Choice</div>
-                <div class="draggable-field" draggable="true" data-type="checkbox"><span class="material-icons me-1">check_box</span> Checkbox</div>
-                <div class="draggable-field" draggable="true" data-type="dropdown"><span class="material-icons me-1">arrow_drop_down_circle</span> Dropdown</div>
-                <div class="draggable-field" draggable="true" data-type="date"><span class="material-icons me-1">event</span> Date</div>
-                <div class="draggable-field" draggable="true" data-type="time"><span class="material-icons me-1">schedule</span> Time</div>
-                <div class="draggable-field" draggable="true" data-type="datetime"><span class="material-icons me-1">event_available</span> Date Time</div>
-                <div class="draggable-field" draggable="true" data-type="scale"><span class="material-icons me-1">linear_scale</span> Linear Scale</div>
-                <div class="draggable-field" draggable="true" data-type="grid_radio"><span class="material-icons me-1">grid_on</span> Choice Grid</div>
-                <div class="draggable-field" draggable="true" data-type="grid_checkbox"><span class="material-icons me-1">grid_view</span> Checkbox Grid</div>
-                <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
-                <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
-                <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
+                <div class="draggable-field" draggable="true" data-type="text">
+                    <span class="material-icons me-1">short_text</span> Short Answer
+                    <div class="toolbox-preview"><input class="form-control" placeholder="Short answer" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="textarea">
+                    <span class="material-icons me-1">notes</span> Paragraph
+                    <div class="toolbox-preview"><textarea class="form-control" placeholder="Paragraph" disabled></textarea></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="radio">
+                    <span class="material-icons me-1">radio_button_checked</span> Multiple Choice
+                    <div class="toolbox-preview">
+                        <div class="form-check"><input class="form-check-input" type="radio" disabled /><label class="form-check-label">Option</label></div>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="checkbox">
+                    <span class="material-icons me-1">check_box</span> Checkbox
+                    <div class="toolbox-preview">
+                        <div class="form-check"><input class="form-check-input" type="checkbox" disabled /><label class="form-check-label">Option</label></div>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="dropdown">
+                    <span class="material-icons me-1">arrow_drop_down_circle</span> Dropdown
+                    <div class="toolbox-preview"><select class="form-select" disabled><option>Option</option></select></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="date">
+                    <span class="material-icons me-1">event</span> Date
+                    <div class="toolbox-preview"><input type="date" class="form-control" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="time">
+                    <span class="material-icons me-1">schedule</span> Time
+                    <div class="toolbox-preview"><input type="time" class="form-control" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="datetime">
+                    <span class="material-icons me-1">event_available</span> Date Time
+                    <div class="toolbox-preview"><input type="datetime-local" class="form-control" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="scale">
+                    <span class="material-icons me-1">linear_scale</span> Linear Scale
+                    <div class="toolbox-preview">
+                        <div class="d-flex gap-1">
+                            @for (var i = 1; i <= 5; i++)
+                            {
+                                <div class="form-check form-check-inline"><input class="form-check-input" type="radio" disabled /><label class="form-check-label">@i</label></div>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="grid_radio">
+                    <span class="material-icons me-1">grid_on</span> Choice Grid
+                    <div class="toolbox-preview">
+                        <table class="table table-bordered table-sm mb-0"><thead><tr><th></th><th>A</th></tr></thead><tbody><tr><th scope="row">1</th><td><input type="radio" disabled /></td></tr></tbody></table>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="grid_checkbox">
+                    <span class="material-icons me-1">grid_view</span> Checkbox Grid
+                    <div class="toolbox-preview">
+                        <table class="table table-bordered table-sm mb-0"><thead><tr><th></th><th>A</th></tr></thead><tbody><tr><th scope="row">1</th><td><input type="checkbox" disabled /></td></tr></tbody></table>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="grid_text">
+                    <span class="material-icons me-1">table_chart</span> Text Grid
+                    <div class="toolbox-preview">
+                        <table class="table table-bordered table-sm mb-0"><thead><tr><th>A</th></tr></thead><tbody><tr><td><input class="form-control" disabled /></td></tr></tbody></table>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="file">
+                    <span class="material-icons me-1">upload_file</span> Upload File
+                    <div class="toolbox-preview"><input type="file" class="form-control" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="image">
+                    <span class="material-icons me-1">image</span> Image
+                    <div class="toolbox-preview"><img src="/images/logo.png" style="max-width:100px" /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="statictext">
+                    <span class="material-icons me-1">text_fields</span> Text
+                    <div class="toolbox-preview"><p class="m-0">Sample text</p></div>
+                </div>
             </div>
             <h6 class="mt-3">User Fields</h6>
             <div class="d-flex flex-wrap gap-2">
-                <div class="draggable-field" draggable="true" data-type="user"><span class="material-icons me-1">person</span> User Dropdown</div>
-                <div class="draggable-field" draggable="true" data-type="department"><span class="material-icons me-1">apartment</span> Department Dropdown</div>
-                <div class="draggable-field" draggable="true" data-type="location"><span class="material-icons me-1">location_on</span> Location Dropdown</div>
+                <div class="draggable-field" draggable="true" data-type="user">
+                    <span class="material-icons me-1">person</span> User Dropdown
+                    <div class="toolbox-preview"><select class="form-select" disabled><option>User</option></select></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="department">
+                    <span class="material-icons me-1">apartment</span> Department Dropdown
+                    <div class="toolbox-preview"><select class="form-select" disabled><option>Department</option></select></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="location">
+                    <span class="material-icons me-1">location_on</span> Location Dropdown
+                    <div class="toolbox-preview"><select class="form-select" disabled><option>Location</option></select></div>
+                </div>
             </div>
         </div>
         <div class="col-md-9">
@@ -170,16 +234,12 @@
 }
 else
 {
-    <div class="row">
-        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
-            <div class="mb-3">
-                <h5 class="mb-0">Toolbox</h5>
-            </div>
+    <div class="preview-overlay">
+        <div class="position-fixed top-0 end-0 m-3">
+            <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Building</button>
         </div>
-        <div class="col-md-9">
-            <div class="card p-3 shadow-sm">
-                <LivePreview Sections="sections" FormName="@formName" />
-            </div>
+        <div class="p-4">
+            <LivePreview Sections="sections" FormName="@formName" />
         </div>
     </div>
 }
@@ -559,6 +619,7 @@ else
                     var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                     var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                     string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
+                        : f.FieldType == "grid_text" && colsList.Count > 0 ? JsonSerializer.Serialize(new { Columns = colsList })
                         : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
                         : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
                         : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
@@ -635,6 +696,17 @@ else
                     Severity = NotificationSeverity.Warning,
                     Summary = "Options Required",
                     Detail = $"Add at least one row and column for '{f.Label}'."
+                });
+                return;
+            }
+
+            if (f.FieldType == "grid_text" && !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one column for '{f.Label}'."
                 });
                 return;
             }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -5,6 +5,7 @@
 @using DynamicFormsApp.Client.Components
 @using DynamicFormsApp.Shared
 @using DynamicFormsApp.Shared.Models
+@using Microsoft.JSInterop
 @inject IJSRuntime JS
 @inject HttpClient Http
 @inject NavigationManager Navigation
@@ -316,6 +317,7 @@ else
             {
                 await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
             }
+            await JS.InvokeAsync<IJSObjectReference>("import", $"/js/dragdrop-wrapper.js?v={AppInfo.Version}");
             await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
             await JS.InvokeVoidAsync("initToolboxPreview");
         }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -2,7 +2,9 @@
 @using System.Net.Http.Json
 @using System.Text.Json
 @using System.Collections.Generic
+@using System.Linq
 @using DynamicFormsApp.Client.Components
+@using DynamicFormsApp.Client.Services
 @using DynamicFormsApp.Shared
 @using DynamicFormsApp.Shared.Models
 @using Microsoft.JSInterop
@@ -11,6 +13,7 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 @inject IUserService UserService
+@inject ComponentServiceProxy ComponentService
 
 @implements IDisposable
 
@@ -113,6 +116,71 @@
                     <div class="toolbox-preview"><p class="m-0">Sample text</p></div>
                 </div>
             </div>
+            @if (customComponents.Any())
+            {
+                <h6 class="mt-3">Saved Components</h6>
+                <div class="d-flex flex-wrap gap-2">
+                    @foreach (var comp in customComponents)
+                    {
+                        var field = comp.Field;
+                        <div class="draggable-field position-relative" draggable="true" data-type="component-@comp.Id">
+                            <span class="material-icons me-1">view_module</span> @comp.Name
+                            @if (comp.CreatedBy == currentUser?.UserName)
+                            {
+                                <button class="btn btn-link btn-sm text-danger position-absolute top-0 end-0" title="Delete" @onclick="() => DeleteComponent(comp.Id)">
+                                    <span class="material-icons" style="font-size:16px">delete</span>
+                                </button>
+                            }
+                            <div class="toolbox-preview">
+                                @if (field?.FieldType == "radio")
+                                {
+                                    foreach (var opt in field.OptionItems.Take(1))
+                                    {
+                                        <div class="form-check"><input class="form-check-input" type="radio" disabled /><label class="form-check-label">@opt</label></div>
+                                    }
+                                }
+                                else if (field?.FieldType == "checkbox")
+                                {
+                                    foreach (var opt in field.OptionItems.Take(1))
+                                    {
+                                        <div class="form-check"><input class="form-check-input" type="checkbox" disabled /><label class="form-check-label">@opt</label></div>
+                                    }
+                                }
+                                else if (field?.FieldType == "dropdown")
+                                {
+                                    <select class="form-select" disabled>
+                                        @foreach (var opt in field.OptionItems.Take(1))
+                                        {
+                                            <option>@opt</option>
+                                        }
+                                    </select>
+                                }
+                                else if (field?.FieldType == "grid_radio")
+                                {
+                                    <table class="table table-bordered table-sm mb-0">
+                                        <thead><tr><th></th>@foreach(var c in field.GridColumns.Take(1)){<th>@c</th>}</tr></thead>
+                                        <tbody>@foreach(var r in field.GridRows.Take(1)){<tr><th scope="row">@r</th><td><input type="radio" disabled /></td></tr>}</tbody>
+                                    </table>
+                                }
+                                else if (field?.FieldType == "grid_checkbox")
+                                {
+                                    <table class="table table-bordered table-sm mb-0">
+                                        <thead><tr><th></th>@foreach(var c in field.GridColumns.Take(1)){<th>@c</th>}</tr></thead>
+                                        <tbody>@foreach(var r in field.GridRows.Take(1)){<tr><th scope="row">@r</th><td><input type="checkbox" disabled /></td></tr>}</tbody>
+                                    </table>
+                                }
+                                else if (field?.FieldType == "grid_text")
+                                {
+                                    <table class="table table-bordered table-sm mb-0">
+                                        <thead><tr>@foreach(var c in field.GridColumns.Take(1)){<th>@c</th>}</tr></thead>
+                                        <tbody><tr><td><input class="form-control" disabled /></td></tr></tbody>
+                                    </table>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
             <h6 class="mt-3">User Fields</h6>
             <div class="d-flex flex-wrap gap-2">
                 <div class="draggable-field" draggable="true" data-type="user">
@@ -208,7 +276,7 @@
                                                 <div class="col-12 col-md-@(12 / (sections[secIndex].Rows[rowIndex].Fields.Count == 0 ? 1 : sections[secIndex].Rows[rowIndex].Fields.Count))" data-id="@i" @key="sections[secIndex].Rows[rowIndex].Fields[i]">
                                                     <FieldEditor Field="sections[secIndex].Rows[rowIndex].Fields[i]"
                                                                  OnRemove="async f => await RemoveField(secIndex, rowIndex, f)"
-                                                                 OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
+                                                                 OnSaveComponent="async f => await SaveComponent(f)" />
                                                 </div>
                                             }
                                         </div>
@@ -258,6 +326,7 @@ else
     private bool ignoreNavigationPrompt = false;
     private List<string> deptOptions = new();
     private List<string> locOptions = new();
+    private List<CustomComponent> customComponents = new();
     private bool restrictionAlertShown = false;
 
     private Stack<List<DesignerSection>> undoStack = new();
@@ -306,7 +375,9 @@ else
             notificationEmail = currentUser?.Email ?? string.Empty;
             deptOptions = await UserService.GetDepartments();
             locOptions = await UserService.GetLocations();
+            customComponents = await ComponentService.GetForDepartment(currentUser?.Department ?? string.Empty);
             objRef ??= DotNetObjectReference.Create(this);
+            StateHasChanged();
         }
 
         if (!isPreviewMode)
@@ -432,28 +503,58 @@ else
         await JS.InvokeVoidAsync("initSortable", $"#section-{sections.Count - 1}-rows", objRef!);
     }
 
-    DesignerField CreateField(string fieldType) => new DesignerField
+    DesignerField CreateField(string fieldType)
     {
-        FieldType = fieldType,
-        Key = fieldType switch
+        if (fieldType.StartsWith("component-") && int.TryParse(fieldType.Substring("component-".Length), out var id))
         {
-            "user" => "select a user",
-            "department" => "department",
-            "location" => "location",
-            _ => string.Empty
-        },
-        Label = fieldType switch
+            var comp = customComponents.FirstOrDefault(c => c.Id == id)?.Field;
+            if (comp != null)
+            {
+                return new DesignerField
+                {
+                    FieldType = comp.FieldType,
+                    Key = comp.Key,
+                    Label = comp.Label,
+                    Instructions = comp.Instructions,
+                    Placeholder = comp.Placeholder,
+                    CharLimit = comp.CharLimit,
+                    MinCharLimit = comp.MinCharLimit,
+                    IsRequired = comp.IsRequired,
+                    ImageUrl = comp.ImageUrl,
+                    ImageWidth = comp.ImageWidth,
+                    ImageHeight = comp.ImageHeight,
+                    OptionItems = new List<string>(comp.OptionItems),
+                    GridRows = new List<string>(comp.GridRows),
+                    GridColumns = new List<string>(comp.GridColumns),
+                    ScaleMin = comp.ScaleMin,
+                    ScaleMax = comp.ScaleMax
+                };
+            }
+        }
+
+        return new DesignerField
         {
-            "user" => "Select a user",
-            "department" => "Department",
-            "location" => "Location",
-            "statictext" => "Text",
-            _ => string.Empty
-        },
-        Placeholder = fieldType == "text" ? "Short answer" :
-                      fieldType == "textarea" ? "Paragraph" :
-                      fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
-    };
+            FieldType = fieldType,
+            Key = fieldType switch
+            {
+                "user" => "select a user",
+                "department" => "department",
+                "location" => "location",
+                _ => string.Empty
+            },
+            Label = fieldType switch
+            {
+                "user" => "Select a user",
+                "department" => "Department",
+                "location" => "Location",
+                "statictext" => "Text",
+                _ => string.Empty
+            },
+            Placeholder = fieldType == "text" ? "Short answer" :
+                          fieldType == "textarea" ? "Paragraph" :
+                          fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
+        };
+    }
 
     async Task RemoveField(int section, int row, DesignerField field)
     {
@@ -466,41 +567,27 @@ else
         await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task DuplicateField(int section, int row, DesignerField field)
+    async Task SaveComponent(DesignerField field)
     {
-        PushUndo();
-        var copy = new DesignerField
+        if (currentUser == null) return;
+        var comp = await ComponentService.Save(field.Label, field, currentUser.Department ?? string.Empty, currentUser.UserName);
+        if (comp != null)
         {
-            Key = field.Key,
-            Label = field.Label,
-            FieldType = field.FieldType,
-            IsRequired = field.IsRequired,
-            CharLimit = field.CharLimit,
-            MinCharLimit = field.MinCharLimit,
-            OptionItems = new List<string>(field.OptionItems),
-            GridColumns = new List<string>(field.GridColumns),
-            GridRows = new List<string>(field.GridRows),
-            ScaleMin = field.ScaleMin,
-            ScaleMax = field.ScaleMax,
-            Placeholder = field.Placeholder,
-            ImageUrl = field.ImageUrl,
-            ImageWidth = field.ImageWidth,
-            ImageHeight = field.ImageHeight
-        };
-        var list = sections[section].Rows[row].Fields;
-        if (list.Count >= 4)
-        {
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Warning,
-                Summary = "Column limit reached",
-                Detail = "A row can contain at most four columns."
-            });
-            return;
+            customComponents.Add(comp);
+            StateHasChanged();
         }
+    }
 
-        list.Insert(list.IndexOf(field) + 1, copy);
-        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
+    async Task DeleteComponent(int id)
+    {
+        if (currentUser == null) return;
+        await ComponentService.Delete(id, currentUser.UserName);
+        var match = customComponents.FirstOrDefault(c => c.Id == id);
+        if (match != null)
+        {
+            customComponents.Remove(match);
+            StateHasChanged();
+        }
     }
 
     [JSInvokable]

--- a/Client/Pages/DynamicForms/Index.razor.css
+++ b/Client/Pages/DynamicForms/Index.razor.css
@@ -1,0 +1,34 @@
+.preview-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    overflow: auto;
+    background-color: #fff;
+    z-index: 1050;
+}
+
+.draggable-field {
+    position: relative;
+}
+
+.draggable-field .toolbox-preview {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 4px;
+    z-index: 1000;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.draggable-field:hover .toolbox-preview {
+    display: block;
+}
+
+.draggable-field .toolbox-preview * {
+    pointer-events: none;
+}

--- a/Client/Pages/DynamicForms/Index.razor.css
+++ b/Client/Pages/DynamicForms/Index.razor.css
@@ -15,20 +15,13 @@
 
 .draggable-field .toolbox-preview {
     display: none;
-    position: absolute;
-    top: 100%;
+    position: fixed;
+    top: 0;
     left: 0;
     background: #fff;
     border: 1px solid #ccc;
     padding: 4px;
     z-index: 1000;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-}
-
-.draggable-field:hover .toolbox-preview {
-    display: block;
-}
-
-.draggable-field .toolbox-preview * {
     pointer-events: none;
 }

--- a/Client/Pages/DynamicForms/Index.razor.css
+++ b/Client/Pages/DynamicForms/Index.razor.css
@@ -13,7 +13,7 @@
     position: relative;
 }
 
-.draggable-field .toolbox-preview {
+.toolbox-preview {
     display: none;
     position: fixed;
     top: 0;
@@ -21,7 +21,7 @@
     background: #fff;
     border: 1px solid #ccc;
     padding: 4px;
-    z-index: 1000;
+    z-index: 9999;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
     pointer-events: none;
 }

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -3,6 +3,8 @@
 @using System.Net
 @using System.Text.Json
 @using System.Linq
+@using System.Text
+@using System.Collections.Generic
 @using DynamicFormsApp.Shared.Models
 @inject HttpClient Http
 @inject NavigationManager Navigation
@@ -72,17 +74,34 @@ else
         <div class="row g-3 mb-3">
         @foreach (var fld in rowGroup)
         {
-            <div class="col-12 col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
-                <div class="mb-3">
-                    @if (fld.FieldType != "image" && fld.FieldType != "statictext")
+            if (fld.FieldType == "section")
+            {
+                <div class="col-12">
+                    <hr />
+                    @if (!string.IsNullOrWhiteSpace(fld.Label))
                     {
-                        <label class="form-label fw-semibold">@fld.Label</label>
+                        <h5>@fld.Label</h5>
                     }
-                    <div class="form-control-plaintext border rounded bg-light p-2" style="color:black">
-                        @DisplayValue(fld)
+                    @if (!string.IsNullOrWhiteSpace(GetInstructions(fld)))
+                    {
+                        <p class="text-muted">@GetInstructions(fld)</p>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="col-12 col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
+                    <div class="mb-3">
+                        @if (fld.FieldType != "image" && fld.FieldType != "statictext")
+                        {
+                            <label class="form-label fw-semibold">@fld.Label</label>
+                        }
+                        <div class="form-control-plaintext border rounded bg-light p-2" style="color:black">
+                            @DisplayValue(fld)
+                        </div>
                     </div>
                 </div>
-            </div>
+            }
         }
         </div>
     }
@@ -246,11 +265,61 @@ else
                 }
             }
         }
+        else if (field.FieldType == "grid_text")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var rows = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(val) ?? new();
+                    var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
+                    var cols = opts?.Columns ?? new List<string>();
+                    var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr>");
+                    foreach (var c in cols)
+                    {
+                        sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
+                    }
+                    sb.Append("</tr></thead><tbody>");
+                    foreach (var row in rows)
+                    {
+                        sb.Append("<tr>");
+                        foreach (var c in cols)
+                        {
+                            row.TryGetValue(c, out var cell);
+                            sb.Append($"<td>{WebUtility.HtmlEncode(cell)}</td>");
+                        }
+                        sb.Append("</tr>");
+                    }
+                    sb.Append("</tbody></table>");
+                    builder.AddMarkupContent(12, sb.ToString());
+                }
+                catch
+                {
+                    builder.AddContent(13, val);
+                }
+            }
+        }
         else
         {
             builder.AddContent(9, val);
         }
     };
+
+    string? GetInstructions(FormField field)
+    {
+        if (string.IsNullOrWhiteSpace(field.OptionsJson))
+            return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(field.OptionsJson);
+            if (doc.RootElement.TryGetProperty("Instructions", out var instEl))
+                return instEl.GetString();
+        }
+        catch
+        {
+        }
+        return null;
+    }
 
     bool IsImage(string path)
     {
@@ -280,12 +349,33 @@ else
             }
             return val;
         }
+        if (field.FieldType == "grid_text")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var rows = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(val) ?? new();
+                    return string.Join(" | ", rows.Select(r => string.Join(", ", r.Select(kv => $"{kv.Key}:{kv.Value}"))));
+                }
+                catch
+                {
+                }
+            }
+            return val;
+        }
         if (field.FieldType == "image" || field.FieldType == "statictext")
         {
             return string.Empty;
         }
 
         return val;
+    }
+
+    private class GridOptions
+    {
+        public List<string>? Rows { get; set; }
+        public List<string>? Columns { get; set; }
     }
 
     private async Task DownloadCsv()

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddScoped(sp =>
 
 builder.Services.AddScoped<IUserService, UserServiceProxy>();
 builder.Services.AddScoped<IEmailService, EmailServiceProxy>();
+builder.Services.AddScoped<ComponentServiceProxy>();
 
 builder.Services.AddScoped<CookieHelper>();
 

--- a/Client/Services/ComponentServiceProxy.cs
+++ b/Client/Services/ComponentServiceProxy.cs
@@ -1,0 +1,34 @@
+using DynamicFormsApp.Shared;
+using DynamicFormsApp.Shared.Models;
+using System.Net.Http.Json;
+
+namespace DynamicFormsApp.Client.Services
+{
+    public class ComponentServiceProxy
+    {
+        private readonly HttpClient _http;
+        public ComponentServiceProxy(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<CustomComponent>> GetForDepartment(string department)
+        {
+            if (string.IsNullOrEmpty(department)) return new List<CustomComponent>();
+            var result = await _http.GetFromJsonAsync<List<CustomComponent>>($"api/components/{Uri.EscapeDataString(department)}");
+            return result ?? new List<CustomComponent>();
+        }
+
+        public async Task<CustomComponent?> Save(string name, DesignerField field, string department, string user)
+        {
+            var resp = await _http.PostAsJsonAsync("api/components", new { Name = name, Field = field, Department = department, CreatedBy = user });
+            if (!resp.IsSuccessStatusCode) return null;
+            return await resp.Content.ReadFromJsonAsync<CustomComponent>();
+        }
+
+        public async Task Delete(int id, string user)
+        {
+            await _http.DeleteAsync($"api/components/{id}?user={Uri.EscapeDataString(user)}");
+        }
+    }
+}

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.11";
+public const string Version = "0.9.12";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.10";
+public const string Version = "0.9.11";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.8";
+public const string Version = "0.9.9";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.12";
+public const string Version = "0.9.13";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.13";
+public const string Version = "0.9.14";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.9";
+public const string Version = "0.9.10";
 }

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.14";
+public const string Version = "0.9.15";
 }

--- a/NdaProcesses.Shared/Models/CustomComponent.cs
+++ b/NdaProcesses.Shared/Models/CustomComponent.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DynamicFormsApp.Shared;
+
+namespace DynamicFormsApp.Shared.Models
+{
+    public class CustomComponent
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string FieldJson { get; set; } = string.Empty;
+        public string CreatedBy { get; set; } = string.Empty;
+        public string Department { get; set; } = string.Empty;
+
+        [NotMapped]
+        [JsonIgnore]
+        public DesignerField? Field => string.IsNullOrWhiteSpace(FieldJson) ? null : JsonSerializer.Deserialize<DesignerField>(FieldJson);
+    }
+}

--- a/Server/Controllers/ComponentsController.cs
+++ b/Server/Controllers/ComponentsController.cs
@@ -1,0 +1,46 @@
+using DynamicFormsApp.Server.Services;
+using DynamicFormsApp.Shared;
+using DynamicFormsApp.Shared.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DynamicFormsApp.Server.Controllers
+{
+    [ApiController]
+    [Route("api/components")]
+    public class ComponentsController : ControllerBase
+    {
+        private readonly ComponentService _service;
+        public ComponentsController(ComponentService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet("{department}")]
+        public async Task<IEnumerable<CustomComponent>> GetByDepartment(string department)
+        {
+            return await _service.GetByDepartmentAsync(department);
+        }
+
+        public class SaveComponentRequest
+        {
+            public string Name { get; set; } = string.Empty;
+            public DesignerField Field { get; set; } = new();
+            public string Department { get; set; } = string.Empty;
+            public string CreatedBy { get; set; } = string.Empty;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<CustomComponent>> Save([FromBody] SaveComponentRequest req)
+        {
+            var comp = await _service.SaveAsync(req.Name, req.Field, req.Department, req.CreatedBy);
+            return Ok(comp);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id, [FromQuery] string user)
+        {
+            await _service.DeleteAsync(id, user);
+            return NoContent();
+        }
+    }
+}

--- a/Server/Data/AppDbContext.cs
+++ b/Server/Data/AppDbContext.cs
@@ -10,6 +10,7 @@ namespace DynamicFormsApp.Server.Data
         public DbSet<Form> Forms { get; set; }
         public DbSet<FormField> FormFields { get; set; }
         public DbSet<DynamicFormsApp.Shared.Models.FormShare> FormShares { get; set; }
+        public DbSet<CustomComponent> CustomComponents { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -27,6 +27,7 @@ builder.Services.AddDbContext<AppDbContext>(opts =>
 
 // Dynamic form service
 builder.Services.AddScoped<DynamicFormService>();
+builder.Services.AddScoped<ComponentService>();
 
 // CORS policy to allow any origin, method, and header
 builder.Services.AddCors(options =>

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -6,6 +6,8 @@ using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Server.Data;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http;
+using System;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,6 +30,12 @@ builder.Services.AddDbContext<AppDbContext>(opts =>
 // Dynamic form service
 builder.Services.AddScoped<DynamicFormService>();
 builder.Services.AddScoped<ComponentService>();
+builder.Services.AddHttpClient<ComponentServiceProxy>((sp, client) =>
+{
+    var accessor = sp.GetRequiredService<IHttpContextAccessor>();
+    var request = accessor.HttpContext?.Request;
+    client.BaseAddress = new Uri($"{request?.Scheme}://{request?.Host}");
+});
 
 // CORS policy to allow any origin, method, and header
 builder.Services.AddCors(options =>

--- a/Server/Services/ComponentService.cs
+++ b/Server/Services/ComponentService.cs
@@ -1,0 +1,49 @@
+using DynamicFormsApp.Server.Data;
+using DynamicFormsApp.Shared;
+using DynamicFormsApp.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+using System.Linq;
+
+namespace DynamicFormsApp.Server.Services
+{
+    public class ComponentService
+    {
+        private readonly AppDbContext _db;
+        public ComponentService(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<CustomComponent> SaveAsync(string name, DesignerField field, string department, string user)
+        {
+            var comp = new CustomComponent
+            {
+                Name = name,
+                FieldJson = JsonSerializer.Serialize(field),
+                Department = department,
+                CreatedBy = user
+            };
+            _db.CustomComponents.Add(comp);
+            await _db.SaveChangesAsync();
+            return comp;
+        }
+
+        public async Task<List<CustomComponent>> GetByDepartmentAsync(string department)
+        {
+            return await _db.CustomComponents
+                .Where(c => c.Department == department)
+                .ToListAsync();
+        }
+
+        public async Task DeleteAsync(int id, string user)
+        {
+            var comp = await _db.CustomComponents.FirstOrDefaultAsync(c => c.Id == id && c.CreatedBy == user);
+            if (comp != null)
+            {
+                _db.CustomComponents.Remove(comp);
+                await _db.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -721,6 +721,7 @@ namespace DynamicFormsApp.Server.Services
             "textarea" => "NVARCHAR(MAX)",
             "grid_radio" => "NVARCHAR(MAX)",    // JSON object
             "grid_checkbox" => "NVARCHAR(MAX)", // JSON object
+            "grid_text" => "NVARCHAR(MAX)",     // JSON array of rows
             "scale" => "INT",
             _ => "NVARCHAR(MAX)"
         };

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -23,21 +23,14 @@
 
     .draggable-field .toolbox-preview {
         display: none;
-        position: absolute;
-        top: 100%;
+        position: fixed;
+        top: 0;
         left: 0;
         background: #fff;
         border: 1px solid #ccc;
         padding: 4px;
         z-index: 1000;
         box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-    }
-
-    .draggable-field:hover .toolbox-preview {
-        display: block;
-    }
-
-    .draggable-field .toolbox-preview * {
         pointer-events: none;
     }
 

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -21,7 +21,7 @@
         background-color: #e9ecef;
     }
 
-    .draggable-field .toolbox-preview {
+    .toolbox-preview {
         display: none;
         position: fixed;
         top: 0;

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -8,6 +8,7 @@
     user-select: none;
     display: inline-flex;
     align-items: center;
+    position: relative;
     flex: 0 0 calc(50% - 0.5rem);
 }
 
@@ -18,6 +19,26 @@
 
     .draggable-field:hover {
         background-color: #e9ecef;
+    }
+
+    .draggable-field .toolbox-preview {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        background: #fff;
+        border: 1px solid #ccc;
+        padding: 4px;
+        z-index: 1000;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    }
+
+    .draggable-field:hover .toolbox-preview {
+        display: block;
+    }
+
+    .draggable-field .toolbox-preview * {
+        pointer-events: none;
     }
 
 /* 📋 Form canvas drop zone */

--- a/Server/wwwroot/js/dragdrop-wrapper.js
+++ b/Server/wwwroot/js/dragdrop-wrapper.js
@@ -96,15 +96,17 @@ window.initToolboxPreview = () => {
         const preview = el.querySelector('.toolbox-preview');
         if (!preview) return;
 
+        const offset = 4;
+
         el.addEventListener('mouseenter', e => {
             preview.style.display = 'block';
-            preview.style.top = (e.clientY + 10) + 'px';
-            preview.style.left = (e.clientX + 10) + 'px';
+            preview.style.top = (e.clientY + offset) + 'px';
+            preview.style.left = (e.clientX + offset) + 'px';
         });
 
         el.addEventListener('mousemove', e => {
-            preview.style.top = (e.clientY + 10) + 'px';
-            preview.style.left = (e.clientX + 10) + 'px';
+            preview.style.top = (e.clientY + offset) + 'px';
+            preview.style.left = (e.clientX + offset) + 'px';
         });
 
         el.addEventListener('mouseleave', () => {

--- a/Server/wwwroot/js/dragdrop-wrapper.js
+++ b/Server/wwwroot/js/dragdrop-wrapper.js
@@ -99,6 +99,7 @@ window.initToolboxPreview = () => {
         const offset = 4;
 
         el.addEventListener('mouseenter', e => {
+            document.body.appendChild(preview);
             preview.style.display = 'block';
             preview.style.top = (e.clientY + offset) + 'px';
             preview.style.left = (e.clientX + offset) + 'px';

--- a/Server/wwwroot/js/dragdrop-wrapper.js
+++ b/Server/wwwroot/js/dragdrop-wrapper.js
@@ -88,3 +88,27 @@ window.focusLastInput = (container) => {
 window.triggerClick = (el) => {
     if (el) el.click();
 };
+
+window.initToolboxPreview = () => {
+    document.querySelectorAll('.draggable-field').forEach(el => {
+        if (el.dataset.previewInit === 'true') return;
+        el.dataset.previewInit = 'true';
+        const preview = el.querySelector('.toolbox-preview');
+        if (!preview) return;
+
+        el.addEventListener('mouseenter', e => {
+            preview.style.display = 'block';
+            preview.style.top = (e.clientY + 10) + 'px';
+            preview.style.left = (e.clientX + 10) + 'px';
+        });
+
+        el.addEventListener('mousemove', e => {
+            preview.style.top = (e.clientY + 10) + 'px';
+            preview.style.left = (e.clientX + 10) + 'px';
+        });
+
+        el.addEventListener('mouseleave', () => {
+            preview.style.display = 'none';
+        });
+    });
+};


### PR DESCRIPTION
## Summary
- show form preview full screen on `/NewForm`
- start text grid responses with one empty row
- display field previews when hovering over toolbox items

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a878187df88329818e4cef9b1a01e2