### PR TITLE
feat: personal components and response labels

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -9,21 +9,24 @@
 
 <div class="card mb-3 shadow-sm field-card" @attributes="AdditionalAttributes">
     <div class="card-body">
-        <div class="d-flex justify-content-between mb-2">
-            <div class="d-flex align-items-center gap-2">
+        <div class="d-flex flex-wrap align-items-start mb-2">
+            <div class="d-flex align-items-center gap-2 flex-grow-1">
                 <span class="drag-handle text-muted"><span class="material-icons fs-4">drag_indicator</span></span>
                 @if (Field.FieldType != "image" && Field.FieldType != "statictext")
                 {
-                    <input class="form-control form-control-sm" placeholder="Field label" @bind="Field.Label" />
+                    <input class="form-control form-control-sm flex-grow-1" placeholder="Field label" @bind="Field.Label" />
                 }
-                <span class="badge bg-secondary">@GetTypeLabel(Field.FieldType)</span>
             </div>
-            <div class="d-flex gap-2">
-                <button class="btn btn-sm btn-outline-secondary" @onclick="() => OnDuplicate.InvokeAsync(Field)">
-                    <span class="material-icons">content_copy</span>
-                </button>
-                <button class="btn btn-sm btn-outline-danger" @onclick="() => OnRemove.InvokeAsync(Field)">
-                    <span class="material-icons">delete</span>
+            <div class="d-flex gap-2 ms-auto mt-2 mt-sm-0">
+                @if (Field.FieldType is "radio" or "checkbox" or "dropdown" or
+                    "grid_radio" or "grid_checkbox" or "grid_text")
+                {
+                    <button class="btn btn-sm btn-outline-primary" title="Save as component" @onclick="() => OnSaveComponent.InvokeAsync(Field)">
+                        <span class="material-icons">save</span>
+                    </button>
+                }
+                <button class="btn btn-outline-danger btn-sm p-1" @onclick="() => OnRemove.InvokeAsync(Field)">
+                    <span class="material-icons" style="font-size:16px;line-height:1">delete</span>
                 </button>
             </div>
         </div>
@@ -68,17 +71,40 @@
                     </div>
                 }
             </div>
-            <div class="d-flex gap-2 mt-1">
+            <div class="d-flex flex-wrap gap-2 mt-1">
                 <button class="btn btn-sm btn-outline-primary" @onclick="AddOption">+ Add Option</button>
                 <button class="btn btn-sm btn-outline-secondary" @onclick="SortOptions">Sort A-Z</button>
             </div>
         }
+        else if (Field.FieldType == "grid_text")
+        {
+            <div class="mt-3">
+                <label class="form-label">Grid Columns</label>
+                <div @ref="gridColsRef">
+                    @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
+                    {
+                        <div class="d-flex align-items-center mb-1">
+                            <input class="form-control flex-grow-1" @bind="Field.GridColumns[idx]" />
+                            <div class="btn-group btn-group-sm ms-1">
+                                <button class="btn btn-outline-secondary" @onclick="() => MoveColumnUp(idx)"><span class="material-icons">arrow_upward</span></button>
+                                <button class="btn btn-outline-secondary" @onclick="() => MoveColumnDown(idx)"><span class="material-icons">arrow_downward</span></button>
+                            </div>
+                            <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => Field.GridColumns.RemoveAt(idx)">×</button>
+                        </div>
+                    }
+                </div>
+                <div class="d-flex flex-wrap gap-2 mt-1">
+                    <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
+                    <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
+                </div>
+            </div>
+        }
         else if (Field.FieldType.StartsWith("grid"))
         {
-            <div class="row mt-3">
+            <div class="row g-2 mt-3">
                 <div class="col-md-6">
                     <label class="form-label">Grid Rows</label>
-                    <div>
+                    <div @ref="gridRowsRef">
                         @foreach (var (row, idx) in Field.GridRows.Select((r, i) => (r, i)))
                         {
                             <div class="d-flex align-items-center mb-1">
@@ -91,13 +117,14 @@
                             </div>
                         }
                     </div>
-                    <div class="mt-1">
+                    <div class="d-flex flex-wrap gap-2 mt-1">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="AddRow">+ Add Row</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortRows">Sort A-Z</button>
                     </div>
                 </div>
                 <div class="col-md-6">
                     <label class="form-label">Grid Columns</label>
-                    <div>
+                    <div @ref="gridColsRef">
                         @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
                         {
                             <div class="d-flex align-items-center mb-1">
@@ -110,7 +137,8 @@
                             </div>
                         }
                     </div>
-                    <div class="mt-1">
+                    <div class="d-flex flex-wrap gap-2 mt-1">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                     </div>
                 </div>
@@ -155,17 +183,22 @@
                 <label class="form-check-label">Required</label>
             </div>
         }
+        <div class="text-end mt-2">
+            <span class="badge bg-secondary">@GetTypeLabel(Field.FieldType)</span>
+        </div>
     </div>
 </div>
 
 @code {
     [Parameter] public DesignerField Field { get; set; }
     [Parameter] public EventCallback<DesignerField> OnRemove { get; set; }
-    [Parameter] public EventCallback<DesignerField> OnDuplicate { get; set; }
+    [Parameter] public EventCallback<DesignerField> OnSaveComponent { get; set; }
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
 
     ElementReference optionsRef;
+    ElementReference gridRowsRef;
+    ElementReference gridColsRef;
     ElementReference imageContainerRef;
     InputFile? imageInput;
     bool imageResizeInit;
@@ -188,6 +221,7 @@
         "scale" => "Linear Scale",
         "grid_radio" => "Choice Grid",
         "grid_checkbox" => "Checkbox Grid",
+        "grid_text" => "Text Grid",
         "title" => "Title",
         "section" => "Section",
         "file" => "Upload File",
@@ -273,6 +307,20 @@
         Field.OptionItems.Add(string.Empty);
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("focusLastInput", optionsRef);
+    }
+
+    async Task AddRow()
+    {
+        Field.GridRows.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("focusLastInput", gridRowsRef);
+    }
+
+    async Task AddColumn()
+    {
+        Field.GridColumns.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("focusLastInput", gridColsRef);
     }
 
     async Task PromptImageUpload()

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -125,6 +125,26 @@
                                 </tbody>
                             </table>
                             break;
+                        case "grid_text":
+                            <table class="table table-bordered table-sm">
+                                <thead>
+                                    <tr>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <th>@col</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <td><input class="form-control" /></td>
+                                        }
+                                    </tr>
+                                </tbody>
+                            </table>
+                            break;
                         case "file":
                             <input type="file" class="form-control" />
                             break;

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -3,7 +3,9 @@
 @using System.Net
 @using System.Text.Json
 @using System.Collections.Generic
+@using System.Linq
 @using DynamicFormsApp.Client.Components
+@using DynamicFormsApp.Client.Services
 @using DynamicFormsApp.Shared
 @using DynamicFormsApp.Shared.Models
 @inject IJSRuntime JS
@@ -11,29 +13,23 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 @inject IUserService UserService
+@inject ComponentServiceProxy ComponentService
 
 @implements IDisposable
 
-<h2 class="mb-2">Form Builder</h2>
-@if (unavailableInfo != null)
-{
-    <FormUnavailableDisplay Info="@unavailableInfo" />
-}
-else if (!string.IsNullOrEmpty(deletedMessage))
-{
-    <div class="alert alert-warning">@deletedMessage</div>
-}
-<p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
-
-@if (isPreviewMode)
-{
-    <div class="mb-3">
-        <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Building</button>
-    </div>
-}
-
 @if (!isPreviewMode)
 {
+    <h2 class="mb-2">Form Builder</h2>
+    @if (unavailableInfo != null)
+    {
+        <FormUnavailableDisplay Info="@unavailableInfo" />
+    }
+    else if (!string.IsNullOrEmpty(deletedMessage))
+    {
+        <div class="alert alert-warning">@deletedMessage</div>
+    }
+    <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
+
     <div class="row">
         <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
             <div class="mb-3 d-flex align-items-center gap-2">
@@ -45,7 +41,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                     <button class="btn btn-secondary btn-sm" @onclick="Redo" disabled="@(!redoStack.Any())">
                         <span class="material-icons">redo</span>
                     </button>
-                    <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Preview</button>
+                    <button class="btn btn-outline-primary btn-sm" @onclick="TogglePreview">Live Mode</button>
                 </div>
             </div>
             <div class="d-flex flex-wrap gap-2">
@@ -60,6 +56,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                 <div class="draggable-field" draggable="true" data-type="scale"><span class="material-icons me-1">linear_scale</span> Linear Scale</div>
                 <div class="draggable-field" draggable="true" data-type="grid_radio"><span class="material-icons me-1">grid_on</span> Choice Grid</div>
                 <div class="draggable-field" draggable="true" data-type="grid_checkbox"><span class="material-icons me-1">grid_view</span> Checkbox Grid</div>
+                <div class="draggable-field" draggable="true" data-type="grid_text"><span class="material-icons me-1">table_chart</span> Text Grid</div>
                 <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
                 <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
                 <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
@@ -70,6 +67,25 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                 <div class="draggable-field" draggable="true" data-type="department"><span class="material-icons me-1">apartment</span> Department Dropdown</div>
                 <div class="draggable-field" draggable="true" data-type="location"><span class="material-icons me-1">location_on</span> Location Dropdown</div>
             </div>
+            @if (customComponents.Any())
+            {
+                <h6 class="mt-3">Saved Components</h6>
+                <div class="d-flex flex-wrap gap-2">
+                    @foreach (var comp in customComponents)
+                    {
+                        var field = comp.Field;
+                        <div class="draggable-field position-relative" draggable="true" data-type="component-@comp.Id">
+                            <span class="material-icons me-1">@GetIcon(field?.FieldType)</span> @comp.Name
+                            @if (comp.CreatedBy == currentUser?.UserName)
+                            {
+                                <button class="btn btn-link btn-sm text-danger position-absolute top-0 end-0" title="Delete" @onclick="() => DeleteComponent(comp.Id)">
+                                    <span class="material-icons" style="font-size:16px">delete</span>
+                                </button>
+                            }
+                        </div>
+                    }
+                </div>
+            }
         </div>
         <div class="col-md-9">
             <div class="mb-4">
@@ -150,7 +166,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                                                 <div class="col-12 col-md-@(12 / (sections[secIndex].Rows[rowIndex].Fields.Count == 0 ? 1 : sections[secIndex].Rows[rowIndex].Fields.Count))" data-id="@i" @key="sections[secIndex].Rows[rowIndex].Fields[i]">
                                                     <FieldEditor Field="sections[secIndex].Rows[rowIndex].Fields[i]"
                                                                  OnRemove="async f => await RemoveField(secIndex, rowIndex, f)"
-                                                                 OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
+                                                                 OnSaveComponent="async f => await SaveComponent(f)" />
                                                 </div>
                                             }
                                         </div>
@@ -186,16 +202,12 @@ else if (!string.IsNullOrEmpty(deletedMessage))
 }
 else
 {
-    <div class="row">
-        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
-            <div class="mb-3">
-                <h5 class="mb-0">Toolbox</h5>
-            </div>
+    <div class="preview-overlay">
+        <div class="position-fixed top-0 end-0 m-3">
+            <button class="btn btn-outline-primary btn-sm" @onclick="TogglePreview">Edit Mode</button>
         </div>
-        <div class="col-md-9">
-            <div class="card p-3 shadow-sm">
-                <LivePreview Sections="sections" FormName="@formName" />
-            </div>
+        <div class="p-4">
+            <LivePreview Sections="sections" FormName="@formName" />
         </div>
     </div>
 }
@@ -216,6 +228,7 @@ else
     private DeletedFormInfo? unavailableInfo;
     private List<string> deptOptions = new();
     private List<string> locOptions = new();
+    private List<CustomComponent> customComponents = new();
     private bool restrictionAlertShown = false;
 
     private Stack<List<DesignerSection>> undoStack = new();
@@ -264,6 +277,7 @@ else
             notificationEmail = currentUser?.Email ?? string.Empty;
             deptOptions = await UserService.GetDepartments();
             locOptions = await UserService.GetLocations();
+            customComponents = await ComponentService.GetForUser(currentUser?.Department ?? string.Empty, currentUser?.UserName ?? string.Empty);
 
             var resp = await Http.GetAsync($"api/forms/{FormId}");
             if (!resp.IsSuccessStatusCode)
@@ -301,7 +315,9 @@ else
             {
                 await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
             }
+            await JS.InvokeAsync<IJSObjectReference>("import", $"/js/dragdrop-wrapper.js?v={AppInfo.Version}");
             await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
+            await JS.InvokeVoidAsync("initToolboxPreview");
         }
     }
 
@@ -405,28 +421,58 @@ public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSecti
     }
 }
 
-    DesignerField CreateField(string fieldType) => new DesignerField
+    DesignerField CreateField(string fieldType)
     {
-        FieldType = fieldType,
-        Key = fieldType switch
+        if (fieldType.StartsWith("component-") && int.TryParse(fieldType.Substring("component-".Length), out var id))
         {
-            "user" => "select a user",
-            "department" => "department",
-            "location" => "location",
-            _ => string.Empty
-        },
-        Label = fieldType switch
+            var comp = customComponents.FirstOrDefault(c => c.Id == id)?.Field;
+            if (comp != null)
+            {
+                return new DesignerField
+                {
+                    FieldType = comp.FieldType,
+                    Key = comp.Key,
+                    Label = comp.Label,
+                    Instructions = comp.Instructions,
+                    Placeholder = comp.Placeholder,
+                    CharLimit = comp.CharLimit,
+                    MinCharLimit = comp.MinCharLimit,
+                    IsRequired = comp.IsRequired,
+                    ImageUrl = comp.ImageUrl,
+                    ImageWidth = comp.ImageWidth,
+                    ImageHeight = comp.ImageHeight,
+                    OptionItems = new List<string>(comp.OptionItems),
+                    GridRows = new List<string>(comp.GridRows),
+                    GridColumns = new List<string>(comp.GridColumns),
+                    ScaleMin = comp.ScaleMin,
+                    ScaleMax = comp.ScaleMax
+                };
+            }
+        }
+
+        return new DesignerField
         {
-            "user" => "Select a user",
-            "department" => "Department",
-            "location" => "Location",
-            "statictext" => "Text",
-            _ => string.Empty
-        },
-        Placeholder = fieldType == "text" ? "Short answer" :
-                      fieldType == "textarea" ? "Paragraph" :
-                      fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
-    };
+            FieldType = fieldType,
+            Key = fieldType switch
+            {
+                "user" => "select a user",
+                "department" => "department",
+                "location" => "location",
+                _ => string.Empty
+            },
+            Label = fieldType switch
+            {
+                "user" => "Select a user",
+                "department" => "Department",
+                "location" => "Location",
+                "statictext" => "Text",
+                _ => string.Empty
+            },
+            Placeholder = fieldType == "text" ? "Short answer" :
+                          fieldType == "textarea" ? "Paragraph" :
+                          fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
+        };
+    }
 
     async Task RemoveField(int section, int row, DesignerField field)
     {
@@ -450,42 +496,80 @@ public void OnSortUpdate(int fromSection, int fromRow, int oldIndex, int toSecti
         await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task DuplicateField(int section, int row, DesignerField field)
+    async Task SaveComponent(DesignerField field)
     {
-        PushUndo();
-        var copy = new DesignerField
+        if (currentUser == null) return;
+        if (string.IsNullOrWhiteSpace(field.Label))
         {
-            Key = field.Key,
-            Label = field.Label,
-            FieldType = field.FieldType,
-            Placeholder = field.Placeholder,
-            CharLimit = field.CharLimit,
-            MinCharLimit = field.MinCharLimit,
-            IsRequired = field.IsRequired,
-            OptionItems = new List<string>(field.OptionItems),
-            GridColumns = new List<string>(field.GridColumns),
-            GridRows = new List<string>(field.GridRows),
-            ScaleMin = field.ScaleMin,
-            ScaleMax = field.ScaleMax,
-            ImageUrl = field.ImageUrl,
-            ImageWidth = field.ImageWidth,
-            ImageHeight = field.ImageHeight
-        };
-        var list = sections[section].Rows[row].Fields;
-        if (list.Count >= 4)
-        {
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Warning,
-                Summary = "Column limit reached",
-                Detail = "A row can contain at most four columns."
-            });
+            await DialogService.Alert("Component name is required.", "Cannot Save");
             return;
         }
-
-        list.Insert(list.IndexOf(field) + 1, copy);
-        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
+        bool requiresOptions = field.FieldType is "radio" or "checkbox" or "dropdown" or
+                                "grid_radio" or "grid_checkbox" or "grid_text";
+        bool hasOptions = true;
+        if (requiresOptions)
+        {
+            hasOptions = field.FieldType switch
+            {
+                "radio" or "checkbox" or "dropdown" => field.OptionItems.Any(o => !string.IsNullOrWhiteSpace(o)),
+                "grid_radio" or "grid_checkbox" => field.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) && field.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)),
+                "grid_text" => field.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)),
+                _ => true
+            };
+        }
+        if (!hasOptions)
+        {
+            await DialogService.Alert("At least one option is required.", "Cannot Save");
+            return;
+        }
+        bool? shareDept = await DialogService.Confirm(
+            "Share this component with your department?", "Save Component",
+            new ConfirmOptions { OkButtonText = "Department", CancelButtonText = "Only Me" });
+        var comp = await ComponentService.Save(field.Label, field,
+            shareDept == true ? currentUser.Department ?? string.Empty : string.Empty,
+            currentUser.UserName);
+        if (comp != null)
+        {
+            customComponents.Add(comp);
+            var msg = shareDept == true
+                ? "This component will be available across your department."
+                : "This component is saved for your use only.";
+            await DialogService.Alert(msg, "Component Saved");
+            StateHasChanged();
+        }
     }
+
+    async Task DeleteComponent(int id)
+    {
+        if (currentUser == null) return;
+        var comp = customComponents.FirstOrDefault(c => c.Id == id);
+        var msg = !string.IsNullOrEmpty(comp?.Department)
+            ? "Are you sure you want to delete this component? It will be removed for everyone in your department."
+            : "Are you sure you want to delete this component?";
+        bool? confirm = await DialogService.Confirm(msg,
+            "Delete Component",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+        if (confirm == true)
+        {
+            await ComponentService.Delete(id, currentUser.UserName);
+            if (comp != null)
+            {
+                customComponents.Remove(comp);
+                StateHasChanged();
+            }
+        }
+    }
+
+    string GetIcon(string? type) => type switch
+    {
+        "radio" => "radio_button_checked",
+        "checkbox" => "check_box",
+        "dropdown" => "arrow_drop_down_circle",
+        "grid_radio" => "grid_on",
+        "grid_checkbox" => "grid_view",
+        "grid_text" => "table_chart",
+        _ => "view_module"
+    };
 
 [JSInvokable]
 public async Task AddFieldFromDrop(string fieldType, int sectionIndex, int rowIndex, int colIndex)
@@ -614,6 +698,7 @@ List<object> BuildFieldPayload()
                 var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                 var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                 string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
+                    : f.FieldType == "grid_text" && colsList.Count > 0 ? JsonSerializer.Serialize(new { Columns = colsList })
                     : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
                     : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
                     : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
@@ -710,7 +795,18 @@ List<object> BuildFieldPayload()
                 {
                     try
                     {
-                        field.OptionItems = JsonSerializer.Deserialize<List<string>>(f.OptionsJson) ?? new();
+                        var optsDoc = JsonDocument.Parse(f.OptionsJson);
+                        if (optsDoc.RootElement.ValueKind == JsonValueKind.Array)
+                        {
+                            field.OptionItems = optsDoc.RootElement.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                        }
+                        else if (optsDoc.RootElement.ValueKind == JsonValueKind.Object)
+                        {
+                            if (optsDoc.RootElement.TryGetProperty("Rows", out var rowsEl) && rowsEl.ValueKind == JsonValueKind.Array)
+                                field.GridRows = rowsEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                            if (optsDoc.RootElement.TryGetProperty("Columns", out var colsEl) && colsEl.ValueKind == JsonValueKind.Array)
+                                field.GridColumns = colsEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList();
+                        }
                     }
                     catch { }
                 }
@@ -775,6 +871,16 @@ List<object> BuildFieldPayload()
                     Severity = NotificationSeverity.Warning,
                     Summary = "Options Required",
                     Detail = $"Add at least one row and column for '{f.Label}'."
+                });
+                return;
+            }
+            if (f.FieldType == "grid_text" && !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one column for '{f.Label}'."
                 });
                 return;
             }

--- a/Client/Pages/DynamicForms/EditFormPage.razor.css
+++ b/Client/Pages/DynamicForms/EditFormPage.razor.css
@@ -1,0 +1,23 @@
+.preview-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    overflow: auto;
+    background-color: #fff;
+    z-index: 1050;
+}
+
+.toolbox-preview {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 4px;
+    z-index: 9999;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    pointer-events: none;
+}

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -58,9 +58,6 @@
                            @bind="field.Label" />
                 </div>
                 <div class="btn-group">
-                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => DuplicateField(index)">
-                        <span class="material-icons">content_copy</span>
-                    </button>
                     <button class="btn btn-sm btn-outline-danger" @onclick="() => RemoveField(field)">
                         <span class="material-icons">delete</span>
                     </button>
@@ -166,21 +163,6 @@
     void RemoveField(DesignerField field)
     {
         fields.Remove(field);
-        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
-    }
-
-    void DuplicateField(int index)
-    {
-        var src = fields[index];
-        var copy = new DesignerField
-        {
-            Key = string.Empty,
-            Label = src.Label,
-            FieldType = src.FieldType,
-            Options = src.Options,
-            IsRequired = src.IsRequired
-        };
-        fields.Insert(index + 1, copy);
         JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -5,6 +5,7 @@
 @using System.Linq
 @using DynamicFormsApp.Shared.Models
 @using System.Net
+@using System.Collections.Generic
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
@@ -110,7 +111,7 @@ else
                             <option value="" disabled selected>Select user...</option>
                             @foreach (var u in directoryUsers)
                             {
-                                <option value="@u.DisplayName">@u.DisplayName - @u.Department - @u.Location</option>
+                                <option value="@u.DisplayName">@FormatUserOption(u)</option>
                             }
                         </select>
                         break;
@@ -156,6 +157,75 @@ else
                                 <label class="form-check-label">@opt</label>
                             </div>
                         }
+                        break;
+
+                    case "grid_radio":
+                    case "grid_checkbox":
+                        var gridOpts = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}");
+                        var gridRows = gridOpts?.Rows ?? new List<string>();
+                        var gridCols = gridOpts?.Columns ?? new List<string>();
+                        <table class="table table-bordered table-sm">
+                            <thead>
+                                <tr>
+                                    <th></th>
+                                    @foreach (var col in gridCols)
+                                    {
+                                        <th>@col</th>
+                                    }
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var row in gridRows)
+                                {
+                                    <tr>
+                                        <td><strong>@row</strong></td>
+                                        @foreach (var col in gridCols)
+                                        {
+                                            <td>
+                                                @if (fld.FieldType == "grid_radio")
+                                                {
+                                                    <input type="radio" name="@($"grid-{fld.Key}-{row}")" value="@col" checked="@(GetGridRadioValue(fld.Key, row) == col)" @onchange="e => OnGridRadioChanged(fld.Key, row, col)" />
+                                                }
+                                                else
+                                                {
+                                                    <input type="checkbox" checked="@IsGridCheckboxChecked(fld.Key, row, col)" @onchange="e => OnGridCheckboxChanged(fld.Key, row, col, e)" />
+                                                }
+                                            </td>
+                                        }
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        break;
+
+                    case "grid_text":
+                        var textOpts = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}");
+                        var textCols = textOpts?.Columns ?? new List<string>();
+                        var textRows = GetGridTextRows(fld.Key, textCols);
+                        <table class="table table-bordered table-sm">
+                            <thead>
+                                <tr>
+                                    @foreach (var col in textCols)
+                                    {
+                                        <th>@col</th>
+                                    }
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var (row, rIdx) in textRows.Select((r, i) => (r, i)))
+                                {
+                                    <tr>
+                                        @foreach (var col in textCols)
+                                        {
+                                            <td><input class="form-control" value="@row[col]" @onchange="e => OnGridTextChanged(fld.Key, rIdx, col, e)" /></td>
+                                        }
+                                        <td><button type="button" class="btn btn-sm btn-danger" @onclick="() => RemoveGridTextRow(fld.Key, rIdx)">Delete</button></td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="() => AddGridTextRow(fld.Key, textCols)">+ Add Row</button>
                         break;
 
                     case "file":
@@ -239,6 +309,14 @@ else
     string GetImageStyle(FormField f) =>
         $"max-width:100%;{(f.ImageWidth.HasValue ? $"width:{f.ImageWidth}px;" : string.Empty)}{(f.ImageHeight.HasValue ? $"height:{f.ImageHeight}px;" : string.Empty)}";
 
+    string FormatUserOption(UserModel u)
+    {
+        var parts = new List<string> { u.DisplayName };
+        if (!string.IsNullOrWhiteSpace(u.Department)) parts.Add(u.Department);
+        if (!string.IsNullOrWhiteSpace(u.Location)) parts.Add(u.Location);
+        return string.Join(" - ", parts);
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
@@ -298,6 +376,9 @@ else
                 responseData[fld.Key] = fld.FieldType switch
                 {
                     "checkbox" => new List<string>(),
+                    "grid_radio" => new Dictionary<string, string>(),
+                    "grid_checkbox" => new Dictionary<string, List<string>>(),
+                    "grid_text" => new List<Dictionary<string, string>>(),
                     "number" => (object?)null,
                     "date" => (object?)null,
                     "time" => (object?)null,
@@ -409,6 +490,83 @@ else
             responseData[key] = dt;
         else
             responseData[key] = null;
+    }
+
+    string? GetGridRadioValue(string key, string row)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is Dictionary<string, string> dict && dict.TryGetValue(row, out var sel))
+            return sel;
+        return null;
+    }
+
+    void OnGridRadioChanged(string key, string row, string col)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not Dictionary<string, string> dict)
+        {
+            dict = new();
+            responseData[key] = dict;
+        }
+        dict[row] = col;
+    }
+
+    bool IsGridCheckboxChecked(string key, string row, string col)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is Dictionary<string, List<string>> dict && dict.TryGetValue(row, out var list))
+            return list.Contains(col);
+        return false;
+    }
+
+    void OnGridCheckboxChanged(string key, string row, string col, ChangeEventArgs e)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not Dictionary<string, List<string>> dict)
+        {
+            dict = new();
+            responseData[key] = dict;
+        }
+        if (!dict.TryGetValue(row, out var list))
+        {
+            list = new();
+            dict[row] = list;
+        }
+        if ((bool?)e.Value == true)
+        {
+            if (!list.Contains(col))
+                list.Add(col);
+        }
+        else
+        {
+            list.Remove(col);
+        }
+    }
+
+    List<Dictionary<string, string>> GetGridTextRows(string key, List<string> cols)
+    {
+        if (!responseData.TryGetValue(key, out var val) || val is not List<Dictionary<string, string>> rows)
+        {
+            rows = new List<Dictionary<string, string>>();
+            responseData[key] = rows;
+        }
+        if (rows.Count == 0)
+            rows.Add(cols.ToDictionary(c => c, c => string.Empty));
+        return rows;
+    }
+
+    void AddGridTextRow(string key, List<string> cols)
+    {
+        var rows = GetGridTextRows(key, cols);
+        rows.Add(cols.ToDictionary(c => c, c => string.Empty));
+    }
+
+    void RemoveGridTextRow(string key, int index)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is List<Dictionary<string, string>> rows && index >= 0 && index < rows.Count)
+            rows.RemoveAt(index);
+    }
+
+    void OnGridTextChanged(string key, int rowIndex, string col, ChangeEventArgs e)
+    {
+        if (responseData.TryGetValue(key, out var val) && val is List<Dictionary<string, string>> rows && rowIndex >= 0 && rowIndex < rows.Count)
+            rows[rowIndex][col] = e.Value?.ToString() ?? string.Empty;
     }
 
     void OnCheckboxChanged(string key, string option, ChangeEventArgs e)
@@ -536,11 +694,20 @@ else
         if (value == null) return true;
         if (value is string s) return string.IsNullOrWhiteSpace(s);
         if (value is IEnumerable<string> list) return !list.Any();
+        if (value is Dictionary<string, string> dr) return dr.Count == 0 || dr.Values.All(string.IsNullOrWhiteSpace);
+        if (value is Dictionary<string, List<string>> dc) return dc.Count == 0 || dc.Values.All(v => v == null || !v.Any());
+        if (value is List<Dictionary<string, string>> tl) return tl.Count == 0 || tl.All(r => r.Values.All(string.IsNullOrWhiteSpace));
         return false;
     }
 
     private class FileUploadResult
     {
         public string filePath { get; set; }
+    }
+
+    private class GridOptions
+    {
+        public List<string>? Rows { get; set; }
+        public List<string>? Columns { get; set; }
     }
 }

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -3,12 +3,14 @@
 @using System.Net
 @using System.Collections.Generic
 @using System.Linq
+@using System.Text.Json
 @using DynamicFormsApp.Shared.Models
 @using Microsoft.AspNetCore.Components
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 @inject IJSRuntime JS
+@inject DialogService DialogService
 @implements IAsyncDisposable
 
 <div class="container mt-4">
@@ -76,6 +78,17 @@
                                     {
                                         <div>@FormatDateTime(row[col]?.ToString())</div>
                                     }
+                                    else if (col == "Status")
+                                    {
+                                        <select class="form-select form-select-sm" value="@GetRowStatus(row)" @onchange="e => ChangeStatus(row, e)">
+                                            <option value="">No Label</option>
+                                            @foreach (var opt in statusOptions)
+                                            {
+                                                <option value="@opt">@statusIcons.GetValueOrDefault(opt, "🏷️") @opt</option>
+                                            }
+                                            <option value="__custom">+ Add label...</option>
+                                        </select>
+                                    }
                                     else
                                     {
                                         <div>@row[col]</div>
@@ -105,7 +118,14 @@
     private string responseIdFilter = string.Empty;
     private string submitFilter = string.Empty;
     private string statusFilter = string.Empty;
-    private List<string> statusOptions = new();
+    private List<string> statusOptions = new() { "Approved", "Pending", "Rejected" };
+    private Dictionary<string, string> statusIcons = new()
+    {
+        ["Approved"] = "✅",
+        ["Pending"] = "⏳",
+        ["Rejected"] = "❌"
+    };
+    private List<string> iconChoices = new() { "🏷️", "✅", "⏳", "❌", "⭐", "⚠️", "📌" };
     private IEnumerable<Dictionary<string, object>> FilteredResponses =>
         responses.Where(row =>
             (string.IsNullOrWhiteSpace(responseIdFilter) || row["ResponseId"].ToString().Contains(responseIdFilter, StringComparison.OrdinalIgnoreCase)) &&
@@ -155,12 +175,24 @@
                 columns = columns.Concat(new[] { "ResponderName" }).ToArray();
             }
 
-            statusOptions = responses
-                .Select(r => r.TryGetValue("Status", out var st) ? st?.ToString() ?? string.Empty : string.Empty)
+            statusOptions = statusOptions
+                .Concat(responses.Select(r => r.TryGetValue("Status", out var st) ? st?.ToString() ?? string.Empty : string.Empty))
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(s => s)
                 .ToList();
+
+            var savedIcons = await JS.InvokeAsync<string>("localStorage.getItem", $"form_{FormId}_statusIcons");
+            if (!string.IsNullOrWhiteSpace(savedIcons))
+            {
+                var stored = JsonSerializer.Deserialize<Dictionary<string, string>>(savedIcons) ?? new();
+                foreach (var kv in stored)
+                {
+                    statusIcons[kv.Key] = kv.Value;
+                    if (!statusOptions.Contains(kv.Key)) statusOptions.Add(kv.Key);
+                }
+                statusOptions = statusOptions.OrderBy(s => s).ToList();
+            }
 
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
             StateHasChanged();
@@ -196,6 +228,41 @@
         {
             await JS.InvokeVoidAsync("exportTableToPdf", "responsesTable", $"{form?.Name ?? "responses"}.pdf");
         }
+    }
+
+    private string GetRowStatus(Dictionary<string, object> row)
+    {
+        return row.TryGetValue("Status", out var st) ? st?.ToString() ?? string.Empty : string.Empty;
+    }
+
+    private async Task ChangeStatus(Dictionary<string, object> row, ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString();
+        var responseId = GetResponseId(row["ResponseId"]);
+        if (value == "__custom")
+        {
+            var result = await DialogService.OpenAsync<StatusLabelDialog>("Add Label", new Dictionary<string, object> { { "Icons", iconChoices } });
+            if (result is StatusLabel custom && !string.IsNullOrWhiteSpace(custom.Label))
+            {
+                if (!statusOptions.Contains(custom.Label)) statusOptions.Add(custom.Label);
+                statusIcons[custom.Label] = custom.Icon;
+                await JS.InvokeVoidAsync("localStorage.setItem", $"form_{FormId}_statusIcons", JsonSerializer.Serialize(statusIcons));
+                row["Status"] = custom.Label;
+                await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{responseId}/status", new { Status = custom.Label });
+                StateHasChanged();
+            }
+        }
+        else
+        {
+            row["Status"] = value ?? string.Empty;
+            await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{responseId}/status", new { Status = row["Status"].ToString() });
+            StateHasChanged();
+        }
+    }
+
+    private int GetResponseId(object idVal)
+    {
+        return idVal is JsonElement je && je.ValueKind == JsonValueKind.Number ? je.GetInt32() : Convert.ToInt32(idVal);
     }
 
     public async ValueTask DisposeAsync()

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -37,6 +37,23 @@
             <button class="btn btn-outline-info me-2" @onclick="DownloadCsv">Download CSV</button>
             <button class="btn btn-outline-info" @onclick="DownloadPdf">Download PDF</button>
         </div>
+        <div class="row g-2 mb-3">
+            <div class="col-auto">
+                <input class="form-control form-control-sm" placeholder="Response ID" @bind="responseIdFilter" />
+            </div>
+            <div class="col-auto">
+                <input class="form-control form-control-sm" placeholder="Submitted By" @bind="submitFilter" />
+            </div>
+            <div class="col-auto">
+                <select class="form-select form-select-sm" @bind="statusFilter">
+                    <option value="">All Statuses</option>
+                    @foreach (var opt in statusOptions)
+                    {
+                        <option value="@opt">@opt</option>
+                    }
+                </select>
+            </div>
+        </div>
         <div class="table-responsive">
             <table id="responsesTable" class="table table-bordered table-hover align-middle">
                 <thead class="table-light">
@@ -46,22 +63,6 @@
                             <th scope="col">@(col switch { "ResponderName" => "Submitted By", "CreatedAt" => "Submitted At", _ => col })</th>
                         }
                         <th scope="col"></th>
-                    </tr>
-                    <tr>
-                        @foreach (var col in columns)
-                        {
-                            <th>
-                                @if (col == "ResponseId")
-                                {
-                                    <input class="form-control form-control-sm" placeholder="Filter" @bind="responseIdFilter" />
-                                }
-                                else if (col == "ResponderName")
-                                {
-                                    <input class="form-control form-control-sm" placeholder="Filter" @bind="submitFilter" />
-                                }
-                            </th>
-                        }
-                        <th></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -103,10 +104,13 @@
     private DeletedFormInfo? unavailableInfo;
     private string responseIdFilter = string.Empty;
     private string submitFilter = string.Empty;
+    private string statusFilter = string.Empty;
+    private List<string> statusOptions = new();
     private IEnumerable<Dictionary<string, object>> FilteredResponses =>
         responses.Where(row =>
             (string.IsNullOrWhiteSpace(responseIdFilter) || row["ResponseId"].ToString().Contains(responseIdFilter, StringComparison.OrdinalIgnoreCase)) &&
-            (string.IsNullOrWhiteSpace(submitFilter) || (row.TryGetValue("ResponderName", out var rn) && rn?.ToString()?.Contains(submitFilter, StringComparison.OrdinalIgnoreCase) == true)));
+            (string.IsNullOrWhiteSpace(submitFilter) || (row.TryGetValue("ResponderName", out var rn) && rn?.ToString()?.Contains(submitFilter, StringComparison.OrdinalIgnoreCase) == true)) &&
+            (string.IsNullOrWhiteSpace(statusFilter) || (row.TryGetValue("Status", out var st) && string.Equals(st?.ToString(), statusFilter, StringComparison.OrdinalIgnoreCase))));
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -145,11 +149,18 @@
             }
             responses = await respData.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
 
-            columns = new[] { "ResponseId", "CreatedAt" };
+            columns = new[] { "ResponseId", "CreatedAt", "Status" };
             if (form.RequireLogin)
             {
                 columns = columns.Concat(new[] { "ResponderName" }).ToArray();
             }
+
+            statusOptions = responses
+                .Select(r => r.TryGetValue("Status", out var st) ? st?.ToString() ?? string.Empty : string.Empty)
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(s => s)
+                .ToList();
 
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
             StateHasChanged();

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -3,6 +3,7 @@
 @using System.Net
 @using System.Text
 @using System.Text.Json
+@using System.Linq
 @using System.Collections.Generic
 @using System
 @using DynamicFormsApp.Shared.Models
@@ -84,11 +85,24 @@
                                     else if (col == "Status")
                                     {
                                         row.TryGetValue(col, out var statusVal);
-                                        <input list="statusOptions" class="form-control form-control-sm" value="@statusVal?.ToString()" @onchange='e => UpdateStatus(row["ResponseId"], e.Value?.ToString())' />
+                                        <select class="form-select form-select-sm" value="@statusVal?.ToString()" @onchange='e => UpdateStatus(row["ResponseId"], e.Value?.ToString())'>
+                                            <option value="">No Label</option>
+                                            <option value="Approved">Approved</option>
+                                            <option value="Pending">Pending</option>
+                                            <option value="Rejected">Rejected</option>
+                                        </select>
                                     }
                                     else if (field?.FieldType == "grid_text")
                                     {
                                         @RenderGridText(row[col]?.ToString(), field)
+                                    }
+                                    else if (field?.FieldType == "grid_radio")
+                                    {
+                                        @RenderGridRadio(row[col]?.ToString(), field)
+                                    }
+                                    else if (field?.FieldType == "grid_checkbox")
+                                    {
+                                        @RenderGridCheckbox(row[col]?.ToString(), field)
                                     }
                                     else if (field?.FieldType == "date")
                                     {
@@ -100,7 +114,7 @@
                                     }
                                     else
                                     {
-                                        <div style="white-space: pre-wrap;">@row[col]</div>
+                                        <div style="white-space: pre-wrap;">@FormatValue(row[col])</div>
                                     }
                                 </td>
                             }
@@ -111,11 +125,6 @@
                     }
                 </tbody>
             </table>
-            <datalist id="statusOptions">
-                <option value="Approved"></option>
-                <option value="Pending"></option>
-                <option value="Rejected"></option>
-            </datalist>
         </div>
     }
 </div>
@@ -245,6 +254,89 @@
         {
             return (MarkupString)val;
         }
+    }
+
+    private MarkupString RenderGridRadio(string? val, FormField field)
+    {
+        if (string.IsNullOrWhiteSpace(val)) return (MarkupString)string.Empty;
+        try
+        {
+            var selections = JsonSerializer.Deserialize<Dictionary<string, string>>(val) ?? new();
+            var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
+            var rows = opts?.Rows ?? new List<string>();
+            var cols = opts?.Columns ?? new List<string>();
+            var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr><th></th>");
+            foreach (var c in cols)
+                sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
+            sb.Append("</tr></thead><tbody>");
+            foreach (var r in rows)
+            {
+                sb.Append("<tr>");
+                sb.Append($"<td><strong>{WebUtility.HtmlEncode(r)}</strong></td>");
+                foreach (var c in cols)
+                {
+                    var mark = selections.TryGetValue(r, out var sel) && sel == c ? "&#10003;" : string.Empty;
+                    sb.Append($"<td>{mark}</td>");
+                }
+                sb.Append("</tr>");
+            }
+            sb.Append("</tbody></table>");
+            return new MarkupString(sb.ToString());
+        }
+        catch
+        {
+            return (MarkupString)val;
+        }
+    }
+
+    private MarkupString RenderGridCheckbox(string? val, FormField field)
+    {
+        if (string.IsNullOrWhiteSpace(val)) return (MarkupString)string.Empty;
+        try
+        {
+            var selections = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(val) ?? new();
+            var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
+            var rows = opts?.Rows ?? new List<string>();
+            var cols = opts?.Columns ?? new List<string>();
+            var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr><th></th>");
+            foreach (var c in cols)
+                sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
+            sb.Append("</tr></thead><tbody>");
+            foreach (var r in rows)
+            {
+                sb.Append("<tr>");
+                sb.Append($"<td><strong>{WebUtility.HtmlEncode(r)}</strong></td>");
+                foreach (var c in cols)
+                {
+                    var mark = selections.TryGetValue(r, out var list) && list.Contains(c) ? "&#10003;" : string.Empty;
+                    sb.Append($"<td>{mark}</td>");
+                }
+                sb.Append("</tr>");
+            }
+            sb.Append("</tbody></table>");
+            return new MarkupString(sb.ToString());
+        }
+        catch
+        {
+            return (MarkupString)val;
+        }
+    }
+
+    private string FormatValue(object? raw)
+    {
+        if (raw is JsonElement je)
+        {
+            if (je.ValueKind == JsonValueKind.Array)
+            {
+                return string.Join(", ", je.EnumerateArray().Select(e => e.ToString()));
+            }
+            if (je.ValueKind == JsonValueKind.Object)
+            {
+                return je.GetRawText();
+            }
+            return je.ToString();
+        }
+        return raw?.ToString() ?? string.Empty;
     }
 
     private class GridOptions

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -1,11 +1,8 @@
 @page "/forms/{FormId:int}/responses"
 @using System.Net.Http.Json
 @using System.Net
-@using System.Text
-@using System.Text.Json
-@using System.Linq
 @using System.Collections.Generic
-@using System
+@using System.Linq
 @using DynamicFormsApp.Shared.Models
 @using Microsoft.AspNetCore.Components
 @inject HttpClient Http
@@ -40,35 +37,31 @@
             <button class="btn btn-outline-info me-2" @onclick="DownloadCsv">Download CSV</button>
             <button class="btn btn-outline-info" @onclick="DownloadPdf">Download PDF</button>
         </div>
-        <div class="row g-2 mb-3">
-            <div class="col-md-3">
-                <input class="form-control" placeholder="Filter by Response ID" @bind="responseIdFilter" />
-            </div>
-            @if (columns.Contains("ResponderName"))
-            {
-                <div class="col-md-3">
-                    <input class="form-control" placeholder="Filter by Submitted By" @bind="submitFilter" />
-                </div>
-            }
-            <div class="col-md-3">
-                <select class="form-select" @bind="statusFilter">
-                    <option value="">All Statuses</option>
-                    @foreach (var opt in statusOptions)
-                    {
-                        <option value="@opt">@statusIcons.GetValueOrDefault(opt, "🏷️") @opt</option>
-                    }
-                </select>
-            </div>
-        </div>
         <div class="table-responsive">
             <table id="responsesTable" class="table table-bordered table-hover align-middle">
                 <thead class="table-light">
                     <tr>
                         @foreach (var col in columns)
                         {
-                            <th scope="col">@(col == "ResponderName" ? "Submitted By" : col)</th>
+                            <th scope="col">@(col switch { "ResponderName" => "Submitted By", "CreatedAt" => "Submitted At", _ => col })</th>
                         }
                         <th scope="col"></th>
+                    </tr>
+                    <tr>
+                        @foreach (var col in columns)
+                        {
+                            <th>
+                                @if (col == "ResponseId")
+                                {
+                                    <input class="form-control form-control-sm" placeholder="Filter" @bind="responseIdFilter" />
+                                }
+                                else if (col == "ResponderName")
+                                {
+                                    <input class="form-control form-control-sm" placeholder="Filter" @bind="submitFilter" />
+                                }
+                            </th>
+                        }
+                        <th></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -78,69 +71,13 @@
                             @foreach (var col in columns)
                             {
                                 <td>
-                                    @{ var field = form.Fields.FirstOrDefault(f => f.Key == col); }
-                                @if (col != "ResponseId" && col != "CreatedAt" && col != "Status" && IsFileField(col))
-                                {
-                                        var url = row[col]?.ToString();
-                                        if (!string.IsNullOrWhiteSpace(url))
-                                        {
-                                            if (url.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
-                                            {
-                                                <iframe src="@($"/" + url)" width="100%" height="200px" style="border: none;"></iframe>
-                                            }
-                                            else if (IsImage(url))
-                                            {
-                                                <img src="@($"/" + url)" class="img-thumbnail" style="max-height: 120px;" />
-                                            }
-                                            else
-                                            {
-                                                <a class="btn btn-sm btn-outline-primary" href="@($"/" + url)" target="_blank">Open File</a>
-                                            }
-                                        }
-                                        else
-                                        {
-                                            <span class="text-muted">No file</span>
-                                        }
-                                    }
-                                else if (col == "Status")
-                                {
-                                    row.TryGetValue(col, out var statusVal);
-                                    <select class="form-select form-select-sm" value="@statusVal?.ToString()" @onchange='e => OnStatusChanged(row, e.Value?.ToString())'>
-                                        <option value="">No Label</option>
-                                        @foreach (var opt in statusOptions)
-                                        {
-                                            <option value="@opt">@statusIcons.GetValueOrDefault(opt, "🏷️") @opt</option>
-                                        }
-                                        <option value="__custom">+ Add label...</option>
-                                    </select>
-                                }
-                                else if (col == "CreatedAt")
-                                {
-                                    <div>@FormatDateTime(row[col]?.ToString())</div>
-                                }
-                                else if (field?.FieldType == "grid_text")
-                                {
-                                    @RenderGridText(row[col]?.ToString(), field)
-                                }
-                                    else if (field?.FieldType == "grid_radio")
-                                    {
-                                        @RenderGridRadio(row[col]?.ToString(), field)
-                                    }
-                                    else if (field?.FieldType == "grid_checkbox")
-                                    {
-                                        @RenderGridCheckbox(row[col]?.ToString(), field)
-                                    }
-                                    else if (field?.FieldType == "date")
-                                    {
-                                        <div>@FormatDate(row[col]?.ToString())</div>
-                                    }
-                                    else if (field?.FieldType == "datetime")
+                                    @if (col == "CreatedAt")
                                     {
                                         <div>@FormatDateTime(row[col]?.ToString())</div>
                                     }
                                     else
                                     {
-                                        <div style="white-space: pre-wrap;">@FormatValue(row[col])</div>
+                                        <div>@row[col]</div>
                                     }
                                 </td>
                             }
@@ -164,21 +101,11 @@
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
     private DeletedFormInfo? unavailableInfo;
-    private List<string> statusOptions = new() { "Approved", "Pending", "Rejected" };
-    private Dictionary<string, string> statusIcons = new()
-    {
-        ["Approved"] = "✅",
-        ["Pending"] = "⏳",
-        ["Rejected"] = "❌"
-    };
-    private List<string> iconChoices = new() { "🏷️", "✅", "⏳", "❌", "⭐", "⚠️", "📌" };
     private string responseIdFilter = string.Empty;
     private string submitFilter = string.Empty;
-    private string statusFilter = string.Empty;
     private IEnumerable<Dictionary<string, object>> FilteredResponses =>
         responses.Where(row =>
             (string.IsNullOrWhiteSpace(responseIdFilter) || row["ResponseId"].ToString().Contains(responseIdFilter, StringComparison.OrdinalIgnoreCase)) &&
-            (string.IsNullOrWhiteSpace(statusFilter) || (row.TryGetValue("Status", out var st) && (st?.ToString() ?? "") == statusFilter)) &&
             (string.IsNullOrWhiteSpace(submitFilter) || (row.TryGetValue("ResponderName", out var rn) && rn?.ToString()?.Contains(submitFilter, StringComparison.OrdinalIgnoreCase) == true)));
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -192,7 +119,6 @@
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
                 return;
             }
-
 
             var respForm = await Http.GetAsync($"api/forms/{FormId}");
             if (!respForm.IsSuccessStatusCode)
@@ -219,37 +145,10 @@
             }
             responses = await respData.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
 
-            var existingStatuses = responses
-                .Where(r => r.TryGetValue("Status", out var s) && !string.IsNullOrWhiteSpace(s?.ToString()))
-                .Select(r => r["Status"].ToString())
-                .Distinct();
-            foreach (var s in existingStatuses)
-            {
-                if (!statusOptions.Contains(s)) statusOptions.Add(s);
-            }
-
-            var savedIcons = await JS.InvokeAsync<string>("localStorage.getItem", $"form_{FormId}_statusIcons");
-            if (!string.IsNullOrWhiteSpace(savedIcons))
-            {
-                var stored = JsonSerializer.Deserialize<Dictionary<string, string>>(savedIcons) ?? new();
-                foreach (var kv in stored)
-                {
-                    statusIcons[kv.Key] = kv.Value;
-                    if (!statusOptions.Contains(kv.Key)) statusOptions.Add(kv.Key);
-                }
-            }
-
-            var fieldKeys = form.Fields
-                .Where(f => f.FieldType != "section" && f.FieldType != "title" && f.FieldType != "image" && f.FieldType != "statictext")
-                .Select(f => f.Key);
-            columns = new[] { "ResponseId", "CreatedAt", "Status" }
-                .Concat(fieldKeys)
-                .ToArray();
+            columns = new[] { "ResponseId", "CreatedAt" };
             if (form.RequireLogin)
             {
-                columns = columns
-                    .Concat(new[] { "ResponderName" })
-                    .ToArray();
+                columns = columns.Concat(new[] { "ResponderName" }).ToArray();
             }
 
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
@@ -257,211 +156,11 @@
         }
     }
 
-    private bool IsFileField(string key)
-    {
-        var field = form?.Fields.FirstOrDefault(f => f.Key == key);
-        return field?.FieldType == "file";
-    }
-
-    private bool IsImage(string path)
-    {
-        var lower = path.ToLowerInvariant();
-        return lower.EndsWith(".jpg") || lower.EndsWith(".jpeg") ||
-               lower.EndsWith(".png") || lower.EndsWith(".gif") ||
-               lower.EndsWith(".bmp") || lower.EndsWith(".webp");
-    }
-
-    private string FormatDate(string? val)
-    {
-        if (DateTime.TryParse(val, out var dt))
-            return dt.ToString("MM/dd/yyyy");
-        return val ?? string.Empty;
-    }
-
     private string FormatDateTime(string? val)
     {
         if (DateTime.TryParse(val, out var dt))
             return dt.ToString("MM/dd/yyyy h:mm tt");
         return val ?? string.Empty;
-    }
-
-    private MarkupString RenderGridText(string? val, FormField field)
-    {
-        if (string.IsNullOrWhiteSpace(val)) return (MarkupString)string.Empty;
-        try
-        {
-            var rows = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(val) ?? new();
-            var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
-            var cols = opts?.Columns ?? new List<string>();
-            var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr>");
-            foreach (var c in cols)
-            {
-                sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
-            }
-            sb.Append("</tr></thead><tbody>");
-            foreach (var row in rows)
-            {
-                sb.Append("<tr>");
-                foreach (var c in cols)
-                {
-                    row.TryGetValue(c, out var cell);
-                    sb.Append($"<td>{WebUtility.HtmlEncode(cell)}</td>");
-                }
-                sb.Append("</tr>");
-            }
-            sb.Append("</tbody></table>");
-            return new MarkupString(sb.ToString());
-        }
-        catch
-        {
-            return (MarkupString)val;
-        }
-    }
-
-    private MarkupString RenderGridRadio(string? val, FormField field)
-    {
-        if (string.IsNullOrWhiteSpace(val)) return (MarkupString)string.Empty;
-        try
-        {
-            var selections = JsonSerializer.Deserialize<Dictionary<string, string>>(val) ?? new();
-            var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
-            var rows = opts?.Rows ?? new List<string>();
-            var cols = opts?.Columns ?? new List<string>();
-            var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr><th></th>");
-            foreach (var c in cols)
-                sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
-            sb.Append("</tr></thead><tbody>");
-            foreach (var r in rows)
-            {
-                sb.Append("<tr>");
-                sb.Append($"<td><strong>{WebUtility.HtmlEncode(r)}</strong></td>");
-                foreach (var c in cols)
-                {
-                    var mark = selections.TryGetValue(r, out var sel) && sel == c ? "&#10003;" : string.Empty;
-                    sb.Append($"<td>{mark}</td>");
-                }
-                sb.Append("</tr>");
-            }
-            sb.Append("</tbody></table>");
-            return new MarkupString(sb.ToString());
-        }
-        catch
-        {
-            return (MarkupString)val;
-        }
-    }
-
-    private MarkupString RenderGridCheckbox(string? val, FormField field)
-    {
-        if (string.IsNullOrWhiteSpace(val)) return (MarkupString)string.Empty;
-        try
-        {
-            var selections = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(val) ?? new();
-            var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
-            var rows = opts?.Rows ?? new List<string>();
-            var cols = opts?.Columns ?? new List<string>();
-            var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr><th></th>");
-            foreach (var c in cols)
-                sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
-            sb.Append("</tr></thead><tbody>");
-            foreach (var r in rows)
-            {
-                sb.Append("<tr>");
-                sb.Append($"<td><strong>{WebUtility.HtmlEncode(r)}</strong></td>");
-                foreach (var c in cols)
-                {
-                    var mark = selections.TryGetValue(r, out var list) && list.Contains(c) ? "&#10003;" : string.Empty;
-                    sb.Append($"<td>{mark}</td>");
-                }
-                sb.Append("</tr>");
-            }
-            sb.Append("</tbody></table>");
-            return new MarkupString(sb.ToString());
-        }
-        catch
-        {
-            return (MarkupString)val;
-        }
-    }
-
-    private string FormatValue(object? raw)
-    {
-        if (raw is JsonElement je)
-        {
-            if (je.ValueKind == JsonValueKind.Array)
-            {
-                return string.Join(", ", je.EnumerateArray().Select(e => e.ToString()));
-            }
-            if (je.ValueKind == JsonValueKind.Object)
-            {
-                return je.GetRawText();
-            }
-            return je.ToString();
-        }
-        return raw?.ToString() ?? string.Empty;
-    }
-
-    private class GridOptions
-    {
-        public List<string>? Rows { get; set; }
-        public List<string>? Columns { get; set; }
-    }
-
-    private async Task OnStatusChanged(Dictionary<string, object> row, string value)
-    {
-        if (value == "__custom")
-        {
-            var result = await DialogService.OpenAsync<StatusLabelDialog>("Add Label",
-                new Dictionary<string, object> { { "Icons", iconChoices } });
-            if (result is StatusLabel custom && !string.IsNullOrWhiteSpace(custom.Label))
-            {
-                if (!statusOptions.Contains(custom.Label)) statusOptions.Add(custom.Label);
-                statusIcons[custom.Label] = custom.Icon;
-                await JS.InvokeVoidAsync("localStorage.setItem", $"form_{FormId}_statusIcons", JsonSerializer.Serialize(statusIcons));
-                await UpdateStatus(row["ResponseId"], custom.Label);
-                row["Status"] = custom.Label;
-            }
-        }
-        else
-        {
-            await UpdateStatus(row["ResponseId"], value);
-            row["Status"] = value;
-        }
-    }
-
-    async Task UpdateStatus(object idObj, string? status)
-    {
-        if (idObj == null) return;
-        int id;
-        if (idObj is JsonElement je && je.ValueKind == JsonValueKind.Number)
-        {
-            id = je.GetInt32();
-        }
-        else
-        {
-            id = Convert.ToInt32(idObj);
-        }
-
-        await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{id}/status", new { Status = status ?? string.Empty });
-
-        var row = responses.FirstOrDefault(r =>
-        {
-            if (r.TryGetValue("ResponseId", out var val))
-            {
-                if (val is JsonElement je2 && je2.ValueKind == JsonValueKind.Number)
-                    return je2.GetInt32() == id;
-                try
-                {
-                    return Convert.ToInt32(val) == id;
-                }
-                catch
-                {
-                    return false;
-                }
-            }
-            return false;
-        });
-        if (row != null) row["Status"] = status;
     }
 
     private async Task DownloadCsv()
@@ -496,3 +195,4 @@
         }
     }
 }
+

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -40,6 +40,26 @@
             <button class="btn btn-outline-info me-2" @onclick="DownloadCsv">Download CSV</button>
             <button class="btn btn-outline-info" @onclick="DownloadPdf">Download PDF</button>
         </div>
+        <div class="row g-2 mb-3">
+            <div class="col-md-3">
+                <input class="form-control" placeholder="Filter by Response ID" @bind="responseIdFilter" />
+            </div>
+            @if (columns.Contains("ResponderName"))
+            {
+                <div class="col-md-3">
+                    <input class="form-control" placeholder="Filter by Submitted By" @bind="submitFilter" />
+                </div>
+            }
+            <div class="col-md-3">
+                <select class="form-select" @bind="statusFilter">
+                    <option value="">All Statuses</option>
+                    @foreach (var opt in statusOptions)
+                    {
+                        <option value="@opt">@statusIcons.GetValueOrDefault(opt, "🏷️") @opt</option>
+                    }
+                </select>
+            </div>
+        </div>
         <div class="table-responsive">
             <table id="responsesTable" class="table table-bordered table-hover align-middle">
                 <thead class="table-light">
@@ -52,7 +72,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach (var row in responses)
+                    @foreach (var row in FilteredResponses)
                     {
                         <tr>
                             @foreach (var col in columns)
@@ -85,11 +105,13 @@
                                     else if (col == "Status")
                                     {
                                         row.TryGetValue(col, out var statusVal);
-                                        <select class="form-select form-select-sm" value="@statusVal?.ToString()" @onchange='e => UpdateStatus(row["ResponseId"], e.Value?.ToString())'>
+                                        <select class="form-select form-select-sm" value="@statusVal?.ToString()" @onchange='e => OnStatusChanged(row, e.Value?.ToString())'>
                                             <option value="">No Label</option>
-                                            <option value="Approved">Approved</option>
-                                            <option value="Pending">Pending</option>
-                                            <option value="Rejected">Rejected</option>
+                                            @foreach (var opt in statusOptions)
+                                            {
+                                                <option value="@opt">@statusIcons.GetValueOrDefault(opt, "🏷️") @opt</option>
+                                            }
+                                            <option value="__custom">+ Add label...</option>
                                         </select>
                                     }
                                     else if (field?.FieldType == "grid_text")
@@ -138,6 +160,21 @@
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
     private DeletedFormInfo? unavailableInfo;
+    private List<string> statusOptions = new() { "Approved", "Pending", "Rejected" };
+    private Dictionary<string, string> statusIcons = new()
+    {
+        ["Approved"] = "✅",
+        ["Pending"] = "⏳",
+        ["Rejected"] = "❌"
+    };
+    private string responseIdFilter = string.Empty;
+    private string submitFilter = string.Empty;
+    private string statusFilter = string.Empty;
+    private IEnumerable<Dictionary<string, object>> FilteredResponses =>
+        responses.Where(row =>
+            (string.IsNullOrWhiteSpace(responseIdFilter) || row["ResponseId"].ToString().Contains(responseIdFilter, StringComparison.OrdinalIgnoreCase)) &&
+            (string.IsNullOrWhiteSpace(statusFilter) || (row.TryGetValue("Status", out var st) && (st?.ToString() ?? "") == statusFilter)) &&
+            (string.IsNullOrWhiteSpace(submitFilter) || (row.TryGetValue("ResponderName", out var rn) && rn?.ToString()?.Contains(submitFilter, StringComparison.OrdinalIgnoreCase) == true)));
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -176,6 +213,15 @@
                 return;
             }
             responses = await respData.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+            var existingStatuses = responses
+                .Where(r => r.TryGetValue("Status", out var s) && !string.IsNullOrWhiteSpace(s?.ToString()))
+                .Select(r => r["Status"].ToString())
+                .Distinct();
+            foreach (var s in existingStatuses)
+            {
+                if (!statusOptions.Contains(s)) statusOptions.Add(s);
+            }
 
             var fieldKeys = form.Fields
                 .Where(f => f.FieldType != "section" && f.FieldType != "title" && f.FieldType != "image" && f.FieldType != "statictext")
@@ -343,6 +389,25 @@
     {
         public List<string>? Rows { get; set; }
         public List<string>? Columns { get; set; }
+    }
+
+    private async Task OnStatusChanged(Dictionary<string, object> row, string value)
+    {
+        if (value == "__custom")
+        {
+            var custom = await JS.InvokeAsync<string>("prompt", "Enter custom status label:");
+            if (!string.IsNullOrWhiteSpace(custom))
+            {
+                if (!statusOptions.Contains(custom)) statusOptions.Add(custom);
+                await UpdateStatus(row["ResponseId"], custom);
+                row["Status"] = custom;
+            }
+        }
+        else
+        {
+            await UpdateStatus(row["ResponseId"], value);
+            row["Status"] = value;
+        }
     }
 
     async Task UpdateStatus(object idObj, string? status)

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -84,7 +84,7 @@
                                     else if (col == "Status")
                                     {
                                         row.TryGetValue(col, out var statusVal);
-                                        <input list="statusOptions" class="form-control form-control-sm" value="@statusVal?.ToString()" @onchange="e => UpdateStatus(row["ResponseId"], e.Value?.ToString())" />
+                                        <input list="statusOptions" class="form-control form-control-sm" value="@statusVal?.ToString()" @onchange='e => UpdateStatus(row["ResponseId"], e.Value?.ToString())' />
                                     }
                                     else if (field?.FieldType == "grid_text")
                                     {

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -167,6 +167,7 @@
         ["Pending"] = "⏳",
         ["Rejected"] = "❌"
     };
+    private List<string> iconChoices = new() { "🏷️", "✅", "⏳", "❌", "⭐", "⚠️", "📌" };
     private string responseIdFilter = string.Empty;
     private string submitFilter = string.Empty;
     private string statusFilter = string.Empty;
@@ -221,6 +222,17 @@
             foreach (var s in existingStatuses)
             {
                 if (!statusOptions.Contains(s)) statusOptions.Add(s);
+            }
+
+            var savedIcons = await JS.InvokeAsync<string>("localStorage.getItem", $"form_{FormId}_statusIcons");
+            if (!string.IsNullOrWhiteSpace(savedIcons))
+            {
+                var stored = JsonSerializer.Deserialize<Dictionary<string, string>>(savedIcons) ?? new();
+                foreach (var kv in stored)
+                {
+                    statusIcons[kv.Key] = kv.Value;
+                    if (!statusOptions.Contains(kv.Key)) statusOptions.Add(kv.Key);
+                }
             }
 
             var fieldKeys = form.Fields
@@ -395,12 +407,15 @@
     {
         if (value == "__custom")
         {
-            var custom = await JS.InvokeAsync<string>("prompt", "Enter custom status label:");
-            if (!string.IsNullOrWhiteSpace(custom))
+            var result = await DialogService.OpenAsync<StatusLabelDialog>("Add Label",
+                new Dictionary<string, object> { { "Icons", iconChoices } });
+            if (result is StatusLabel custom && !string.IsNullOrWhiteSpace(custom.Label))
             {
-                if (!statusOptions.Contains(custom)) statusOptions.Add(custom);
-                await UpdateStatus(row["ResponseId"], custom);
-                row["Status"] = custom;
+                if (!statusOptions.Contains(custom.Label)) statusOptions.Add(custom.Label);
+                statusIcons[custom.Label] = custom.Icon;
+                await JS.InvokeVoidAsync("localStorage.setItem", $"form_{FormId}_statusIcons", JsonSerializer.Serialize(statusIcons));
+                await UpdateStatus(row["ResponseId"], custom.Label);
+                row["Status"] = custom.Label;
             }
         }
         else

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -102,22 +102,26 @@
                                             <span class="text-muted">No file</span>
                                         }
                                     }
-                                    else if (col == "Status")
-                                    {
-                                        row.TryGetValue(col, out var statusVal);
-                                        <select class="form-select form-select-sm" value="@statusVal?.ToString()" @onchange='e => OnStatusChanged(row, e.Value?.ToString())'>
-                                            <option value="">No Label</option>
-                                            @foreach (var opt in statusOptions)
-                                            {
-                                                <option value="@opt">@statusIcons.GetValueOrDefault(opt, "🏷️") @opt</option>
-                                            }
-                                            <option value="__custom">+ Add label...</option>
-                                        </select>
-                                    }
-                                    else if (field?.FieldType == "grid_text")
-                                    {
-                                        @RenderGridText(row[col]?.ToString(), field)
-                                    }
+                                else if (col == "Status")
+                                {
+                                    row.TryGetValue(col, out var statusVal);
+                                    <select class="form-select form-select-sm" value="@statusVal?.ToString()" @onchange='e => OnStatusChanged(row, e.Value?.ToString())'>
+                                        <option value="">No Label</option>
+                                        @foreach (var opt in statusOptions)
+                                        {
+                                            <option value="@opt">@statusIcons.GetValueOrDefault(opt, "🏷️") @opt</option>
+                                        }
+                                        <option value="__custom">+ Add label...</option>
+                                    </select>
+                                }
+                                else if (col == "CreatedAt")
+                                {
+                                    <div>@FormatDateTime(row[col]?.ToString())</div>
+                                }
+                                else if (field?.FieldType == "grid_text")
+                                {
+                                    @RenderGridText(row[col]?.ToString(), field)
+                                }
                                     else if (field?.FieldType == "grid_radio")
                                     {
                                         @RenderGridRadio(row[col]?.ToString(), field)
@@ -428,9 +432,35 @@
     async Task UpdateStatus(object idObj, string? status)
     {
         if (idObj == null) return;
-        int id = Convert.ToInt32(idObj);
+        int id;
+        if (idObj is JsonElement je && je.ValueKind == JsonValueKind.Number)
+        {
+            id = je.GetInt32();
+        }
+        else
+        {
+            id = Convert.ToInt32(idObj);
+        }
+
         await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{id}/status", new { Status = status ?? string.Empty });
-        var row = responses.FirstOrDefault(r => Convert.ToInt32(r["ResponseId"]) == id);
+
+        var row = responses.FirstOrDefault(r =>
+        {
+            if (r.TryGetValue("ResponseId", out var val))
+            {
+                if (val is JsonElement je2 && je2.ValueKind == JsonValueKind.Number)
+                    return je2.GetInt32() == id;
+                try
+                {
+                    return Convert.ToInt32(val) == id;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+            return false;
+        });
         if (row != null) row["Status"] = status;
     }
 

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -1,6 +1,10 @@
 @page "/forms/{FormId:int}/responses"
 @using System.Net.Http.Json
 @using System.Net
+@using System.Text
+@using System.Text.Json
+@using System.Collections.Generic
+@using System
 @using DynamicFormsApp.Shared.Models
 @using Microsoft.AspNetCore.Components
 @inject HttpClient Http
@@ -53,8 +57,9 @@
                             @foreach (var col in columns)
                             {
                                 <td>
-                                    @if (col != "ResponseId" && col != "CreatedAt" && IsFileField(col))
-                                    {
+                                    @{ var field = form.Fields.FirstOrDefault(f => f.Key == col); }
+                                @if (col != "ResponseId" && col != "CreatedAt" && col != "Status" && IsFileField(col))
+                                {
                                         var url = row[col]?.ToString();
                                         if (!string.IsNullOrWhiteSpace(url))
                                         {
@@ -76,6 +81,23 @@
                                             <span class="text-muted">No file</span>
                                         }
                                     }
+                                    else if (col == "Status")
+                                    {
+                                        row.TryGetValue(col, out var statusVal);
+                                        <input list="statusOptions" class="form-control form-control-sm" value="@statusVal?.ToString()" @onchange="e => UpdateStatus(row["ResponseId"], e.Value?.ToString())" />
+                                    }
+                                    else if (field?.FieldType == "grid_text")
+                                    {
+                                        @RenderGridText(row[col]?.ToString(), field)
+                                    }
+                                    else if (field?.FieldType == "date")
+                                    {
+                                        <div>@FormatDate(row[col]?.ToString())</div>
+                                    }
+                                    else if (field?.FieldType == "datetime")
+                                    {
+                                        <div>@FormatDateTime(row[col]?.ToString())</div>
+                                    }
                                     else
                                     {
                                         <div style="white-space: pre-wrap;">@row[col]</div>
@@ -89,6 +111,11 @@
                     }
                 </tbody>
             </table>
+            <datalist id="statusOptions">
+                <option value="Approved"></option>
+                <option value="Pending"></option>
+                <option value="Rejected"></option>
+            </datalist>
         </div>
     }
 </div>
@@ -144,7 +171,7 @@
             var fieldKeys = form.Fields
                 .Where(f => f.FieldType != "section" && f.FieldType != "title" && f.FieldType != "image" && f.FieldType != "statictext")
                 .Select(f => f.Key);
-            columns = new[] { "ResponseId", "CreatedAt" }
+            columns = new[] { "ResponseId", "CreatedAt", "Status" }
                 .Concat(fieldKeys)
                 .ToArray();
             if (form.RequireLogin)
@@ -171,6 +198,68 @@
         return lower.EndsWith(".jpg") || lower.EndsWith(".jpeg") ||
                lower.EndsWith(".png") || lower.EndsWith(".gif") ||
                lower.EndsWith(".bmp") || lower.EndsWith(".webp");
+    }
+
+    private string FormatDate(string? val)
+    {
+        if (DateTime.TryParse(val, out var dt))
+            return dt.ToString("MM/dd/yyyy");
+        return val ?? string.Empty;
+    }
+
+    private string FormatDateTime(string? val)
+    {
+        if (DateTime.TryParse(val, out var dt))
+            return dt.ToString("MM/dd/yyyy h:mm tt");
+        return val ?? string.Empty;
+    }
+
+    private MarkupString RenderGridText(string? val, FormField field)
+    {
+        if (string.IsNullOrWhiteSpace(val)) return (MarkupString)string.Empty;
+        try
+        {
+            var rows = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(val) ?? new();
+            var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
+            var cols = opts?.Columns ?? new List<string>();
+            var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr>");
+            foreach (var c in cols)
+            {
+                sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
+            }
+            sb.Append("</tr></thead><tbody>");
+            foreach (var row in rows)
+            {
+                sb.Append("<tr>");
+                foreach (var c in cols)
+                {
+                    row.TryGetValue(c, out var cell);
+                    sb.Append($"<td>{WebUtility.HtmlEncode(cell)}</td>");
+                }
+                sb.Append("</tr>");
+            }
+            sb.Append("</tbody></table>");
+            return new MarkupString(sb.ToString());
+        }
+        catch
+        {
+            return (MarkupString)val;
+        }
+    }
+
+    private class GridOptions
+    {
+        public List<string>? Rows { get; set; }
+        public List<string>? Columns { get; set; }
+    }
+
+    async Task UpdateStatus(object idObj, string? status)
+    {
+        if (idObj == null) return;
+        int id = Convert.ToInt32(idObj);
+        await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{id}/status", new { Status = status ?? string.Empty });
+        var row = responses.FirstOrDefault(r => Convert.ToInt32(r["ResponseId"]) == id);
+        if (row != null) row["Status"] = status;
     }
 
     private async Task DownloadCsv()

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -2,31 +2,27 @@
 @using System.Net.Http.Json
 @using System.Text.Json
 @using System.Collections.Generic
+@using System.Linq
 @using DynamicFormsApp.Client.Components
+@using DynamicFormsApp.Client.Services
 @using DynamicFormsApp.Shared
 @using DynamicFormsApp.Shared.Models
+@using Microsoft.JSInterop
 @inject IJSRuntime JS
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 @inject IUserService UserService
+@inject ComponentServiceProxy ComponentService
 
 @implements IDisposable
 
 <NavigationLock OnBeforeInternalNavigation="PromptDraft" ConfirmExternalNavigation="true" />
 
-<h2 class="mb-2">Form Builder</h2>
-<p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
-
-@if (isPreviewMode)
-{
-    <div class="mb-3">
-        <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Building</button>
-    </div>
-}
-
 @if (!isPreviewMode)
 {
+    <h2 class="mb-2">Form Builder</h2>
+    <p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
     <div class="row">
         <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
             <div class="mb-3 d-flex align-items-center gap-2">
@@ -38,31 +34,168 @@
                     <button class="btn btn-secondary btn-sm" @onclick="Redo" disabled="@(!redoStack.Any())">
                         <span class="material-icons">redo</span>
                     </button>
-                    <button class="btn btn-secondary btn-sm" @onclick="TogglePreview">Preview</button>
+                    <button class="btn btn-outline-primary btn-sm" @onclick="TogglePreview">Live Mode</button>
                 </div>
             </div>
             <div class="d-flex flex-wrap gap-2">
-                <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
-                <div class="draggable-field" draggable="true" data-type="textarea"><span class="material-icons me-1">notes</span> Paragraph</div>
-                <div class="draggable-field" draggable="true" data-type="radio"><span class="material-icons me-1">radio_button_checked</span> Multiple Choice</div>
-                <div class="draggable-field" draggable="true" data-type="checkbox"><span class="material-icons me-1">check_box</span> Checkbox</div>
-                <div class="draggable-field" draggable="true" data-type="dropdown"><span class="material-icons me-1">arrow_drop_down_circle</span> Dropdown</div>
-                <div class="draggable-field" draggable="true" data-type="date"><span class="material-icons me-1">event</span> Date</div>
-                <div class="draggable-field" draggable="true" data-type="time"><span class="material-icons me-1">schedule</span> Time</div>
-                <div class="draggable-field" draggable="true" data-type="datetime"><span class="material-icons me-1">event_available</span> Date Time</div>
-                <div class="draggable-field" draggable="true" data-type="scale"><span class="material-icons me-1">linear_scale</span> Linear Scale</div>
-                <div class="draggable-field" draggable="true" data-type="grid_radio"><span class="material-icons me-1">grid_on</span> Choice Grid</div>
-                <div class="draggable-field" draggable="true" data-type="grid_checkbox"><span class="material-icons me-1">grid_view</span> Checkbox Grid</div>
-                <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
-                <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
-                <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
+                <div class="draggable-field" draggable="true" data-type="text">
+                    <span class="material-icons me-1">short_text</span> Short Answer
+                    <div class="toolbox-preview"><input class="form-control" placeholder="Short answer" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="textarea">
+                    <span class="material-icons me-1">notes</span> Paragraph
+                    <div class="toolbox-preview"><textarea class="form-control" placeholder="Paragraph" disabled></textarea></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="radio">
+                    <span class="material-icons me-1">radio_button_checked</span> Multiple Choice
+                    <div class="toolbox-preview">
+                        <div class="form-check"><input class="form-check-input" type="radio" disabled /><label class="form-check-label">Option</label></div>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="checkbox">
+                    <span class="material-icons me-1">check_box</span> Checkbox
+                    <div class="toolbox-preview">
+                        <div class="form-check"><input class="form-check-input" type="checkbox" disabled /><label class="form-check-label">Option</label></div>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="dropdown">
+                    <span class="material-icons me-1">arrow_drop_down_circle</span> Dropdown
+                    <div class="toolbox-preview"><select class="form-select" disabled><option>Option</option></select></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="date">
+                    <span class="material-icons me-1">event</span> Date
+                    <div class="toolbox-preview"><input type="date" class="form-control" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="time">
+                    <span class="material-icons me-1">schedule</span> Time
+                    <div class="toolbox-preview"><input type="time" class="form-control" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="datetime">
+                    <span class="material-icons me-1">event_available</span> Date Time
+                    <div class="toolbox-preview"><input type="datetime-local" class="form-control" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="scale">
+                    <span class="material-icons me-1">linear_scale</span> Linear Scale
+                    <div class="toolbox-preview">
+                        <div class="d-flex gap-1">
+                            @for (var i = 1; i <= 5; i++)
+                            {
+                                <div class="form-check form-check-inline"><input class="form-check-input" type="radio" disabled /><label class="form-check-label">@i</label></div>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="grid_radio">
+                    <span class="material-icons me-1">grid_on</span> Choice Grid
+                    <div class="toolbox-preview">
+                        <table class="table table-bordered table-sm mb-0"><thead><tr><th></th><th>A</th></tr></thead><tbody><tr><th scope="row">1</th><td><input type="radio" disabled /></td></tr></tbody></table>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="grid_checkbox">
+                    <span class="material-icons me-1">grid_view</span> Checkbox Grid
+                    <div class="toolbox-preview">
+                        <table class="table table-bordered table-sm mb-0"><thead><tr><th></th><th>A</th></tr></thead><tbody><tr><th scope="row">1</th><td><input type="checkbox" disabled /></td></tr></tbody></table>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="grid_text">
+                    <span class="material-icons me-1">table_chart</span> Text Grid
+                    <div class="toolbox-preview">
+                        <table class="table table-bordered table-sm mb-0"><thead><tr><th>A</th></tr></thead><tbody><tr><td><input class="form-control" disabled /></td></tr></tbody></table>
+                    </div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="file">
+                    <span class="material-icons me-1">upload_file</span> Upload File
+                    <div class="toolbox-preview"><input type="file" class="form-control" disabled /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="image">
+                    <span class="material-icons me-1">image</span> Image
+                    <div class="toolbox-preview"><img src="/images/logo.png" style="max-width:100px" /></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="statictext">
+                    <span class="material-icons me-1">text_fields</span> Text
+                    <div class="toolbox-preview"><p class="m-0">Sample text</p></div>
+                </div>
             </div>
             <h6 class="mt-3">User Fields</h6>
             <div class="d-flex flex-wrap gap-2">
-                <div class="draggable-field" draggable="true" data-type="user"><span class="material-icons me-1">person</span> User Dropdown</div>
-                <div class="draggable-field" draggable="true" data-type="department"><span class="material-icons me-1">apartment</span> Department Dropdown</div>
-                <div class="draggable-field" draggable="true" data-type="location"><span class="material-icons me-1">location_on</span> Location Dropdown</div>
+                <div class="draggable-field" draggable="true" data-type="user">
+                    <span class="material-icons me-1">person</span> User Dropdown
+                    <div class="toolbox-preview"><select class="form-select" disabled><option>User</option></select></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="department">
+                    <span class="material-icons me-1">apartment</span> Department Dropdown
+                    <div class="toolbox-preview"><select class="form-select" disabled><option>Department</option></select></div>
+                </div>
+                <div class="draggable-field" draggable="true" data-type="location">
+                    <span class="material-icons me-1">location_on</span> Location Dropdown
+                    <div class="toolbox-preview"><select class="form-select" disabled><option>Location</option></select></div>
+                </div>
             </div>
+            @if (customComponents.Any())
+            {
+                <h6 class="mt-3">Saved Components</h6>
+                <div class="d-flex flex-wrap gap-2">
+                    @foreach (var comp in customComponents)
+                    {
+                        var field = comp.Field;
+                        <div class="draggable-field position-relative" draggable="true" data-type="component-@comp.Id">
+                            <span class="material-icons me-1">@GetIcon(field?.FieldType)</span> @comp.Name
+                            @if (comp.CreatedBy == currentUser?.UserName)
+                            {
+                                <button class="btn btn-link btn-sm text-danger position-absolute top-0 end-0" title="Delete" @onclick="() => DeleteComponent(comp.Id)">
+                                    <span class="material-icons" style="font-size:16px">delete</span>
+                                </button>
+                            }
+                            <div class="toolbox-preview">
+                                @if (field?.FieldType == "radio")
+                                {
+                                    foreach (var opt in field.OptionItems.Take(1))
+                                    {
+                                        <div class="form-check"><input class="form-check-input" type="radio" disabled /><label class="form-check-label">@opt</label></div>
+                                    }
+                                }
+                                else if (field?.FieldType == "checkbox")
+                                {
+                                    foreach (var opt in field.OptionItems.Take(1))
+                                    {
+                                        <div class="form-check"><input class="form-check-input" type="checkbox" disabled /><label class="form-check-label">@opt</label></div>
+                                    }
+                                }
+                                else if (field?.FieldType == "dropdown")
+                                {
+                                    <select class="form-select" disabled>
+                                        @foreach (var opt in field.OptionItems.Take(1))
+                                        {
+                                            <option>@opt</option>
+                                        }
+                                    </select>
+                                }
+                                else if (field?.FieldType == "grid_radio")
+                                {
+                                    <table class="table table-bordered table-sm mb-0">
+                                        <thead><tr><th></th>@foreach(var c in field.GridColumns.Take(1)){<th>@c</th>}</tr></thead>
+                                        <tbody>@foreach(var r in field.GridRows.Take(1)){<tr><th scope="row">@r</th><td><input type="radio" disabled /></td></tr>}</tbody>
+                                    </table>
+                                }
+                                else if (field?.FieldType == "grid_checkbox")
+                                {
+                                    <table class="table table-bordered table-sm mb-0">
+                                        <thead><tr><th></th>@foreach(var c in field.GridColumns.Take(1)){<th>@c</th>}</tr></thead>
+                                        <tbody>@foreach(var r in field.GridRows.Take(1)){<tr><th scope="row">@r</th><td><input type="checkbox" disabled /></td></tr>}</tbody>
+                                    </table>
+                                }
+                                else if (field?.FieldType == "grid_text")
+                                {
+                                    <table class="table table-bordered table-sm mb-0">
+                                        <thead><tr>@foreach(var c in field.GridColumns.Take(1)){<th>@c</th>}</tr></thead>
+                                        <tbody><tr><td><input class="form-control" disabled /></td></tr></tbody>
+                                    </table>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
         </div>
         <div class="col-md-9">
             <div class="mb-4">
@@ -143,7 +276,7 @@
                                                 <div class="col-12 col-md-@(12 / (sections[secIndex].Rows[rowIndex].Fields.Count == 0 ? 1 : sections[secIndex].Rows[rowIndex].Fields.Count))" data-id="@i" @key="sections[secIndex].Rows[rowIndex].Fields[i]">
                                                     <FieldEditor Field="sections[secIndex].Rows[rowIndex].Fields[i]"
                                                                  OnRemove="async f => await RemoveField(secIndex, rowIndex, f)"
-                                                                 OnDuplicate="async f => await DuplicateField(secIndex, rowIndex, f)" />
+                                                                 OnSaveComponent="async f => await SaveComponent(f)" />
                                                 </div>
                                             }
                                         </div>
@@ -170,16 +303,12 @@
 }
 else
 {
-    <div class="row">
-        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
-            <div class="mb-3">
-                <h5 class="mb-0">Toolbox</h5>
-            </div>
+    <div class="preview-overlay">
+        <div class="position-fixed top-0 end-0 m-3">
+            <button class="btn btn-outline-primary btn-sm" @onclick="TogglePreview">Edit Mode</button>
         </div>
-        <div class="col-md-9">
-            <div class="card p-3 shadow-sm">
-                <LivePreview Sections="sections" FormName="@formName" />
-            </div>
+        <div class="p-4">
+            <LivePreview Sections="sections" FormName="@formName" />
         </div>
     </div>
 }
@@ -197,6 +326,7 @@ else
     private bool ignoreNavigationPrompt = false;
     private List<string> deptOptions = new();
     private List<string> locOptions = new();
+    private List<CustomComponent> customComponents = new();
     private bool restrictionAlertShown = false;
 
     private Stack<List<DesignerSection>> undoStack = new();
@@ -245,7 +375,9 @@ else
             notificationEmail = currentUser?.Email ?? string.Empty;
             deptOptions = await UserService.GetDepartments();
             locOptions = await UserService.GetLocations();
+            customComponents = await ComponentService.GetForUser(currentUser?.Department ?? string.Empty, currentUser?.UserName ?? string.Empty);
             objRef ??= DotNetObjectReference.Create(this);
+            StateHasChanged();
         }
 
         if (!isPreviewMode)
@@ -256,7 +388,9 @@ else
             {
                 await JS.InvokeVoidAsync("initSortable", $"#section-{i}-rows", objRef);
             }
+            await JS.InvokeAsync<IJSObjectReference>("import", $"/js/dragdrop-wrapper.js?v={AppInfo.Version}");
             await JS.InvokeVoidAsync("initFieldDragDrop", "#sections-container", objRef);
+            await JS.InvokeVoidAsync("initToolboxPreview");
         }
     }
 
@@ -369,28 +503,58 @@ else
         await JS.InvokeVoidAsync("initSortable", $"#section-{sections.Count - 1}-rows", objRef!);
     }
 
-    DesignerField CreateField(string fieldType) => new DesignerField
+    DesignerField CreateField(string fieldType)
     {
-        FieldType = fieldType,
-        Key = fieldType switch
+        if (fieldType.StartsWith("component-") && int.TryParse(fieldType.Substring("component-".Length), out var id))
         {
-            "user" => "select a user",
-            "department" => "department",
-            "location" => "location",
-            _ => string.Empty
-        },
-        Label = fieldType switch
+            var comp = customComponents.FirstOrDefault(c => c.Id == id)?.Field;
+            if (comp != null)
+            {
+                return new DesignerField
+                {
+                    FieldType = comp.FieldType,
+                    Key = comp.Key,
+                    Label = comp.Label,
+                    Instructions = comp.Instructions,
+                    Placeholder = comp.Placeholder,
+                    CharLimit = comp.CharLimit,
+                    MinCharLimit = comp.MinCharLimit,
+                    IsRequired = comp.IsRequired,
+                    ImageUrl = comp.ImageUrl,
+                    ImageWidth = comp.ImageWidth,
+                    ImageHeight = comp.ImageHeight,
+                    OptionItems = new List<string>(comp.OptionItems),
+                    GridRows = new List<string>(comp.GridRows),
+                    GridColumns = new List<string>(comp.GridColumns),
+                    ScaleMin = comp.ScaleMin,
+                    ScaleMax = comp.ScaleMax
+                };
+            }
+        }
+
+        return new DesignerField
         {
-            "user" => "Select a user",
-            "department" => "Department",
-            "location" => "Location",
-            "statictext" => "Text",
-            _ => string.Empty
-        },
-        Placeholder = fieldType == "text" ? "Short answer" :
-                      fieldType == "textarea" ? "Paragraph" :
-                      fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
-    };
+            FieldType = fieldType,
+            Key = fieldType switch
+            {
+                "user" => "select a user",
+                "department" => "department",
+                "location" => "location",
+                _ => string.Empty
+            },
+            Label = fieldType switch
+            {
+                "user" => "Select a user",
+                "department" => "Department",
+                "location" => "Location",
+                "statictext" => "Text",
+                _ => string.Empty
+            },
+            Placeholder = fieldType == "text" ? "Short answer" :
+                          fieldType == "textarea" ? "Paragraph" :
+                          fieldType == "dropdown" ? "Select one from dropdown" : string.Empty
+        };
+    }
 
     async Task RemoveField(int section, int row, DesignerField field)
     {
@@ -403,42 +567,80 @@ else
         await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
     }
 
-    async Task DuplicateField(int section, int row, DesignerField field)
+    async Task SaveComponent(DesignerField field)
     {
-        PushUndo();
-        var copy = new DesignerField
+        if (currentUser == null) return;
+        if (string.IsNullOrWhiteSpace(field.Label))
         {
-            Key = field.Key,
-            Label = field.Label,
-            FieldType = field.FieldType,
-            IsRequired = field.IsRequired,
-            CharLimit = field.CharLimit,
-            MinCharLimit = field.MinCharLimit,
-            OptionItems = new List<string>(field.OptionItems),
-            GridColumns = new List<string>(field.GridColumns),
-            GridRows = new List<string>(field.GridRows),
-            ScaleMin = field.ScaleMin,
-            ScaleMax = field.ScaleMax,
-            Placeholder = field.Placeholder,
-            ImageUrl = field.ImageUrl,
-            ImageWidth = field.ImageWidth,
-            ImageHeight = field.ImageHeight
-        };
-        var list = sections[section].Rows[row].Fields;
-        if (list.Count >= 4)
-        {
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Warning,
-                Summary = "Column limit reached",
-                Detail = "A row can contain at most four columns."
-            });
+            await DialogService.Alert("Component name is required.", "Cannot Save");
             return;
         }
-
-        list.Insert(list.IndexOf(field) + 1, copy);
-        await JS.InvokeVoidAsync("initSortable", $"#section-{section}-rows", objRef!);
+        bool requiresOptions = field.FieldType is "radio" or "checkbox" or "dropdown" or
+                                "grid_radio" or "grid_checkbox" or "grid_text";
+        bool hasOptions = true;
+        if (requiresOptions)
+        {
+            hasOptions = field.FieldType switch
+            {
+                "radio" or "checkbox" or "dropdown" => field.OptionItems.Any(o => !string.IsNullOrWhiteSpace(o)),
+                "grid_radio" or "grid_checkbox" => field.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) && field.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)),
+                "grid_text" => field.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)),
+                _ => true
+            };
+        }
+        if (!hasOptions)
+        {
+            await DialogService.Alert("At least one option is required.", "Cannot Save");
+            return;
+        }
+        bool? shareDept = await DialogService.Confirm(
+            "Share this component with your department?", "Save Component",
+            new ConfirmOptions { OkButtonText = "Department", CancelButtonText = "Only Me" });
+        var comp = await ComponentService.Save(field.Label, field,
+            shareDept == true ? currentUser.Department ?? string.Empty : string.Empty,
+            currentUser.UserName);
+        if (comp != null)
+        {
+            customComponents.Add(comp);
+            var msg = shareDept == true
+                ? "This component will be available across your department."
+                : "This component is saved for your use only.";
+            await DialogService.Alert(msg, "Component Saved");
+            StateHasChanged();
+        }
     }
+
+    async Task DeleteComponent(int id)
+    {
+        if (currentUser == null) return;
+        var comp = customComponents.FirstOrDefault(c => c.Id == id);
+        var msg = !string.IsNullOrEmpty(comp?.Department)
+            ? "Are you sure you want to delete this component? It will be removed for everyone in your department."
+            : "Are you sure you want to delete this component?";
+        bool? confirm = await DialogService.Confirm(msg,
+            "Delete Component",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+        if (confirm == true)
+        {
+            await ComponentService.Delete(id, currentUser.UserName);
+            if (comp != null)
+            {
+                customComponents.Remove(comp);
+                StateHasChanged();
+            }
+        }
+    }
+
+    string GetIcon(string? type) => type switch
+    {
+        "radio" => "radio_button_checked",
+        "checkbox" => "check_box",
+        "dropdown" => "arrow_drop_down_circle",
+        "grid_radio" => "grid_on",
+        "grid_checkbox" => "grid_view",
+        "grid_text" => "table_chart",
+        _ => "view_module"
+    };
 
     [JSInvokable]
     public async Task AddFieldFromDrop(string fieldType, int sectionIndex, int rowIndex, int colIndex)
@@ -559,6 +761,7 @@ else
                     var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                     var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                     string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
+                        : f.FieldType == "grid_text" && colsList.Count > 0 ? JsonSerializer.Serialize(new { Columns = colsList })
                         : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
                         : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
                         : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
@@ -635,6 +838,17 @@ else
                     Severity = NotificationSeverity.Warning,
                     Summary = "Options Required",
                     Detail = $"Add at least one row and column for '{f.Label}'."
+                });
+                return;
+            }
+
+            if (f.FieldType == "grid_text" && !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one column for '{f.Label}'."
                 });
                 return;
             }

--- a/Client/Pages/DynamicForms/Index.razor.css
+++ b/Client/Pages/DynamicForms/Index.razor.css
@@ -1,0 +1,27 @@
+.preview-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    overflow: auto;
+    background-color: #fff;
+    z-index: 1050;
+}
+
+.draggable-field {
+    position: relative;
+}
+
+.toolbox-preview {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 4px;
+    z-index: 9999;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    pointer-events: none;
+}

--- a/Client/Pages/DynamicForms/StatusLabelDialog.razor
+++ b/Client/Pages/DynamicForms/StatusLabelDialog.razor
@@ -1,0 +1,51 @@
+<RadzenCard Style="width:100%;max-width:400px">
+    <RadzenStack Gap="0.75rem">
+        <div>
+            <RadzenLabel Text="Label" />
+            <RadzenTextBox @bind-Value="label" Style="width:100%" />
+        </div>
+        <div>
+            <RadzenLabel Text="Icon" />
+            <RadzenDropDown Data="iconOptions" @bind-Value="selectedIcon" Style="width:100%">
+                <Template Context="icon">
+                    <span style="font-size:1.25rem">@icon</span>
+                </Template>
+            </RadzenDropDown>
+        </div>
+        <div class="d-flex justify-content-end">
+            <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Secondary" class="me-2" Click="@(() => DialogService.Close(null))" />
+            <RadzenButton Text="Save" ButtonStyle="ButtonStyle.Primary" Click="Save" />
+        </div>
+    </RadzenStack>
+</RadzenCard>
+
+@code {
+    [Parameter] public IEnumerable<string>? Icons { get; set; }
+
+    private List<string> iconOptions = new() { "🏷️", "✅", "⏳", "❌", "⭐", "⚠️", "📌" };
+    private string label = string.Empty;
+    private string selectedIcon = "🏷️";
+
+    protected override void OnInitialized()
+    {
+        if (Icons != null)
+        {
+            iconOptions = Icons.ToList();
+        }
+        if (iconOptions.Count > 0)
+        {
+            selectedIcon = iconOptions[0];
+        }
+    }
+
+    private async Task Save()
+    {
+        if (string.IsNullOrWhiteSpace(label))
+        {
+            await DialogService.Alert("Label name is required.", "Add Label");
+            return;
+        }
+        var result = new StatusLabel { Label = label.Trim(), Icon = selectedIcon };
+        DialogService.Close(result);
+    }
+}

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -503,7 +503,7 @@ else
                 try
                 {
                     var dict = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(val) ?? new();
-                    return string.Join(" | ", dict.Select(kv => $"{kv.Key}:{string.Join(\", \", kv.Value)}"));
+                    return string.Join(" | ", dict.Select(kv => $"{kv.Key}:{string.Join(", ", kv.Value)}"));
                 }
                 catch { }
             }

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -3,6 +3,8 @@
 @using System.Net
 @using System.Text.Json
 @using System.Linq
+@using System.Text
+@using System.Collections.Generic
 @using DynamicFormsApp.Shared.Models
 @inject HttpClient Http
 @inject NavigationManager Navigation
@@ -20,6 +22,15 @@
     </div>
 
 </div>
+<div class="mb-3">
+    <label class="form-label">Status</label>
+    <input list="statusOptions" class="form-control w-auto" value="@status" @onchange="OnStatusChanged" />
+</div>
+<datalist id="statusOptions">
+    <option value="Approved"></option>
+    <option value="Pending"></option>
+    <option value="Rejected"></option>
+</datalist>
 @if (unavailableInfo != null)
 {
     <FormUnavailableDisplay Info="@unavailableInfo" />
@@ -72,17 +83,34 @@ else
         <div class="row g-3 mb-3">
         @foreach (var fld in rowGroup)
         {
-            <div class="col-12 col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
-                <div class="mb-3">
-                    @if (fld.FieldType != "image" && fld.FieldType != "statictext")
+            if (fld.FieldType == "section")
+            {
+                <div class="col-12">
+                    <hr />
+                    @if (!string.IsNullOrWhiteSpace(fld.Label))
                     {
-                        <label class="form-label fw-semibold">@fld.Label</label>
+                        <h5>@fld.Label</h5>
                     }
-                    <div class="form-control-plaintext border rounded bg-light p-2" style="color:black">
-                        @DisplayValue(fld)
+                    @if (!string.IsNullOrWhiteSpace(GetInstructions(fld)))
+                    {
+                        <p class="text-muted">@GetInstructions(fld)</p>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="col-12 col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
+                    <div class="mb-3">
+                        @if (fld.FieldType != "image" && fld.FieldType != "statictext")
+                        {
+                            <label class="form-label fw-semibold">@fld.Label</label>
+                        }
+                        <div class="form-control-plaintext border rounded bg-light p-2" style="color:black">
+                            @DisplayValue(fld)
+                        </div>
                     </div>
                 </div>
-            </div>
+            }
         }
         </div>
     }
@@ -115,6 +143,7 @@ else
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
     private DeletedFormInfo? unavailableInfo;
+    private string status = string.Empty;
 
     int? PrevId =>
         responseIds != null && responseIds.IndexOf(ResponseId) > 0
@@ -183,11 +212,21 @@ else
         {
             responderName = respName?.ToString();
         }
+        if (response.TryGetValue("Status", out var st))
+        {
+            status = st?.ToString() ?? string.Empty;
+        }
 
         if (exportModule == null)
         {
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
         }
+    }
+
+    async Task OnStatusChanged(ChangeEventArgs e)
+    {
+        status = e.Value?.ToString() ?? string.Empty;
+        await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{ResponseId}/status", new { Status = status });
     }
 
     RenderFragment DisplayValue(FormField field) => builder =>
@@ -246,11 +285,75 @@ else
                 }
             }
         }
+        else if (field.FieldType == "grid_text")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var rows = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(val) ?? new();
+                    var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
+                    var cols = opts?.Columns ?? new List<string>();
+                    var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr>");
+                    foreach (var c in cols)
+                    {
+                        sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
+                    }
+                    sb.Append("</tr></thead><tbody>");
+                    foreach (var row in rows)
+                    {
+                        sb.Append("<tr>");
+                        foreach (var c in cols)
+                        {
+                            row.TryGetValue(c, out var cell);
+                            sb.Append($"<td>{WebUtility.HtmlEncode(cell)}</td>");
+                        }
+                        sb.Append("</tr>");
+                    }
+                    sb.Append("</tbody></table>");
+                    builder.AddMarkupContent(12, sb.ToString());
+                }
+                catch
+                {
+                    builder.AddContent(13, val);
+                }
+            }
+        }
+        else if (field.FieldType == "date")
+        {
+            if (DateTime.TryParse(val, out var dt))
+                builder.AddContent(9, dt.ToString("MM/dd/yyyy"));
+            else
+                builder.AddContent(9, val);
+        }
+        else if (field.FieldType == "datetime")
+        {
+            if (DateTime.TryParse(val, out var dt))
+                builder.AddContent(9, dt.ToString("MM/dd/yyyy h:mm tt"));
+            else
+                builder.AddContent(9, val);
+        }
         else
         {
             builder.AddContent(9, val);
         }
     };
+
+    string? GetInstructions(FormField field)
+    {
+        if (string.IsNullOrWhiteSpace(field.OptionsJson))
+            return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(field.OptionsJson);
+            if (doc.RootElement.TryGetProperty("Instructions", out var instEl))
+                return instEl.GetString();
+        }
+        catch
+        {
+        }
+        return null;
+    }
 
     bool IsImage(string path)
     {
@@ -280,12 +383,47 @@ else
             }
             return val;
         }
+        if (field.FieldType == "grid_text")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var rows = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(val) ?? new();
+                    return string.Join(" | ", rows.Select(r => string.Join(", ", r.Select(kv => $"{kv.Key}:{kv.Value}"))));
+                }
+                catch
+                {
+                }
+            }
+            return val;
+        }
         if (field.FieldType == "image" || field.FieldType == "statictext")
         {
             return string.Empty;
         }
 
+        if (field.FieldType == "date")
+        {
+            if (DateTime.TryParse(val, out var dt))
+                return dt.ToString("MM/dd/yyyy");
+            return val;
+        }
+
+        if (field.FieldType == "datetime")
+        {
+            if (DateTime.TryParse(val, out var dt))
+                return dt.ToString("MM/dd/yyyy h:mm tt");
+            return val;
+        }
+
         return val;
+    }
+
+    private class GridOptions
+    {
+        public List<string>? Rows { get; set; }
+        public List<string>? Columns { get; set; }
     }
 
     private async Task DownloadCsv()

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -153,6 +153,7 @@ else
         ["Pending"] = "⏳",
         ["Rejected"] = "❌"
     };
+    private List<string> iconChoices = new() { "🏷️", "✅", "⏳", "❌", "⭐", "⚠️", "📌" };
 
     int? PrevId =>
         responseIds != null && responseIds.IndexOf(ResponseId) > 0
@@ -230,6 +231,17 @@ else
             }
         }
 
+        var savedIcons = await JS.InvokeAsync<string>("localStorage.getItem", $"form_{FormId}_statusIcons");
+        if (!string.IsNullOrWhiteSpace(savedIcons))
+        {
+            var stored = JsonSerializer.Deserialize<Dictionary<string, string>>(savedIcons) ?? new();
+            foreach (var kv in stored)
+            {
+                statusIcons[kv.Key] = kv.Value;
+                if (!statusOptions.Contains(kv.Key)) statusOptions.Add(kv.Key);
+            }
+        }
+
         if (exportModule == null)
         {
             exportModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/exportHelper.js");
@@ -241,11 +253,14 @@ else
         var value = e.Value?.ToString();
         if (value == "__custom")
         {
-            var custom = await JS.InvokeAsync<string>("prompt", "Enter custom status label:");
-            if (!string.IsNullOrWhiteSpace(custom))
+            var result = await DialogService.OpenAsync<StatusLabelDialog>("Add Label",
+                new Dictionary<string, object> { { "Icons", iconChoices } });
+            if (result is StatusLabel custom && !string.IsNullOrWhiteSpace(custom.Label))
             {
-                if (!statusOptions.Contains(custom)) statusOptions.Add(custom);
-                status = custom;
+                if (!statusOptions.Contains(custom.Label)) statusOptions.Add(custom.Label);
+                statusIcons[custom.Label] = custom.Icon;
+                await JS.InvokeVoidAsync("localStorage.setItem", $"form_{FormId}_statusIcons", JsonSerializer.Serialize(statusIcons));
+                status = custom.Label;
                 await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{ResponseId}/status", new { Status = status });
             }
         }

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -26,9 +26,11 @@
     <label class="form-label">Status</label>
     <select class="form-select w-auto" value="@status" @onchange="OnStatusChanged">
         <option value="">No Label</option>
-        <option value="Approved">Approved</option>
-        <option value="Pending">Pending</option>
-        <option value="Rejected">Rejected</option>
+        @foreach (var opt in statusOptions)
+        {
+            <option value="@opt">@statusIcons.GetValueOrDefault(opt, "🏷️") @opt</option>
+        }
+        <option value="__custom">+ Add label...</option>
     </select>
 </div>
 @if (unavailableInfo != null)
@@ -144,6 +146,13 @@ else
     private string? deletedMessage;
     private DeletedFormInfo? unavailableInfo;
     private string status = string.Empty;
+    private List<string> statusOptions = new() { "Approved", "Pending", "Rejected" };
+    private Dictionary<string, string> statusIcons = new()
+    {
+        ["Approved"] = "✅",
+        ["Pending"] = "⏳",
+        ["Rejected"] = "❌"
+    };
 
     int? PrevId =>
         responseIds != null && responseIds.IndexOf(ResponseId) > 0
@@ -215,6 +224,10 @@ else
         if (response.TryGetValue("Status", out var st))
         {
             status = st?.ToString() ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(status) && !statusOptions.Contains(status))
+            {
+                statusOptions.Add(status);
+            }
         }
 
         if (exportModule == null)
@@ -225,8 +238,22 @@ else
 
     async Task OnStatusChanged(ChangeEventArgs e)
     {
-        status = e.Value?.ToString() ?? string.Empty;
-        await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{ResponseId}/status", new { Status = status });
+        var value = e.Value?.ToString();
+        if (value == "__custom")
+        {
+            var custom = await JS.InvokeAsync<string>("prompt", "Enter custom status label:");
+            if (!string.IsNullOrWhiteSpace(custom))
+            {
+                if (!statusOptions.Contains(custom)) statusOptions.Add(custom);
+                status = custom;
+                await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{ResponseId}/status", new { Status = status });
+            }
+        }
+        else
+        {
+            status = value ?? string.Empty;
+            await Http.PutAsJsonAsync($"api/forms/{FormId}/responses/{ResponseId}/status", new { Status = status });
+        }
     }
 
     RenderFragment DisplayValue(FormField field) => builder =>

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -24,13 +24,13 @@
 </div>
 <div class="mb-3">
     <label class="form-label">Status</label>
-    <input list="statusOptions" class="form-control w-auto" value="@status" @onchange="OnStatusChanged" />
+    <select class="form-select w-auto" value="@status" @onchange="OnStatusChanged">
+        <option value="">No Label</option>
+        <option value="Approved">Approved</option>
+        <option value="Pending">Pending</option>
+        <option value="Rejected">Rejected</option>
+    </select>
 </div>
-<datalist id="statusOptions">
-    <option value="Approved"></option>
-    <option value="Pending"></option>
-    <option value="Rejected"></option>
-</datalist>
 @if (unavailableInfo != null)
 {
     <FormUnavailableDisplay Info="@unavailableInfo" />
@@ -319,6 +319,74 @@ else
                 }
             }
         }
+        else if (field.FieldType == "grid_radio")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var selections = JsonSerializer.Deserialize<Dictionary<string, string>>(val) ?? new();
+                    var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
+                    var rows = opts?.Rows ?? new List<string>();
+                    var cols = opts?.Columns ?? new List<string>();
+                    var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr><th></th>");
+                    foreach (var c in cols)
+                        sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
+                    sb.Append("</tr></thead><tbody>");
+                    foreach (var r in rows)
+                    {
+                        sb.Append("<tr>");
+                        sb.Append($"<td><strong>{WebUtility.HtmlEncode(r)}</strong></td>");
+                        foreach (var c in cols)
+                        {
+                            var mark = selections.TryGetValue(r, out var sel) && sel == c ? "&#10003;" : string.Empty;
+                            sb.Append($"<td>{mark}</td>");
+                        }
+                        sb.Append("</tr>");
+                    }
+                    sb.Append("</tbody></table>");
+                    builder.AddMarkupContent(14, sb.ToString());
+                }
+                catch
+                {
+                    builder.AddContent(15, val);
+                }
+            }
+        }
+        else if (field.FieldType == "grid_checkbox")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var selections = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(val) ?? new();
+                    var opts = JsonSerializer.Deserialize<GridOptions>(field.OptionsJson ?? "{}");
+                    var rows = opts?.Rows ?? new List<string>();
+                    var cols = opts?.Columns ?? new List<string>();
+                    var sb = new StringBuilder("<table class='table table-bordered table-sm mb-0'><thead><tr><th></th>");
+                    foreach (var c in cols)
+                        sb.Append($"<th>{WebUtility.HtmlEncode(c)}</th>");
+                    sb.Append("</tr></thead><tbody>");
+                    foreach (var r in rows)
+                    {
+                        sb.Append("<tr>");
+                        sb.Append($"<td><strong>{WebUtility.HtmlEncode(r)}</strong></td>");
+                        foreach (var c in cols)
+                        {
+                            var mark = selections.TryGetValue(r, out var list) && list.Contains(c) ? "&#10003;" : string.Empty;
+                            sb.Append($"<td>{mark}</td>");
+                        }
+                        sb.Append("</tr>");
+                    }
+                    sb.Append("</tbody></table>");
+                    builder.AddMarkupContent(16, sb.ToString());
+                }
+                catch
+                {
+                    builder.AddContent(17, val);
+                }
+            }
+        }
         else if (field.FieldType == "date")
         {
             if (DateTime.TryParse(val, out var dt))
@@ -335,7 +403,7 @@ else
         }
         else
         {
-            builder.AddContent(9, val);
+            builder.AddContent(9, FormatValue(valObj));
         }
     };
 
@@ -361,6 +429,23 @@ else
         return lower.EndsWith(".jpg") || lower.EndsWith(".jpeg") ||
                lower.EndsWith(".png") || lower.EndsWith(".gif") ||
                lower.EndsWith(".bmp") || lower.EndsWith(".webp");
+    }
+
+    string FormatValue(object? val)
+    {
+        if (val is JsonElement je)
+        {
+            if (je.ValueKind == JsonValueKind.Array)
+            {
+                return string.Join(", ", je.EnumerateArray().Select(e => e.ToString()));
+            }
+            if (je.ValueKind == JsonValueKind.Object)
+            {
+                return je.GetRawText();
+            }
+            return je.ToString();
+        }
+        return val?.ToString() ?? string.Empty;
     }
 
     string ValueAsString(FormField field)
@@ -398,6 +483,32 @@ else
             }
             return val;
         }
+        if (field.FieldType == "grid_radio")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(val) ?? new();
+                    return string.Join(" | ", dict.Select(kv => $"{kv.Key}:{kv.Value}"));
+                }
+                catch { }
+            }
+            return val;
+        }
+        if (field.FieldType == "grid_checkbox")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var dict = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(val) ?? new();
+                    return string.Join(" | ", dict.Select(kv => $"{kv.Key}:{string.Join(\", \", kv.Value)}"));
+                }
+                catch { }
+            }
+            return val;
+        }
         if (field.FieldType == "image" || field.FieldType == "statictext")
         {
             return string.Empty;
@@ -417,7 +528,7 @@ else
             return val;
         }
 
-        return val;
+        return FormatValue(valObj);
     }
 
     private class GridOptions

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddScoped(sp =>
 
 builder.Services.AddScoped<IUserService, UserServiceProxy>();
 builder.Services.AddScoped<IEmailService, EmailServiceProxy>();
+builder.Services.AddScoped<ComponentServiceProxy>();
 
 builder.Services.AddScoped<CookieHelper>();
 

--- a/Client/Services/ComponentServiceProxy.cs
+++ b/Client/Services/ComponentServiceProxy.cs
@@ -1,0 +1,34 @@
+using DynamicFormsApp.Shared;
+using DynamicFormsApp.Shared.Models;
+using System.Net.Http.Json;
+
+namespace DynamicFormsApp.Client.Services
+{
+    public class ComponentServiceProxy
+    {
+        private readonly HttpClient _http;
+        public ComponentServiceProxy(HttpClient http)
+        {
+            _http = http;
+        }
+
+        public async Task<List<CustomComponent>> GetForUser(string department, string user)
+        {
+            if (string.IsNullOrEmpty(department) && string.IsNullOrEmpty(user)) return new List<CustomComponent>();
+            var result = await _http.GetFromJsonAsync<List<CustomComponent>>($"api/components/{Uri.EscapeDataString(department)}?user={Uri.EscapeDataString(user)}");
+            return result ?? new List<CustomComponent>();
+        }
+
+        public async Task<CustomComponent?> Save(string name, DesignerField field, string department, string user)
+        {
+            var resp = await _http.PostAsJsonAsync("api/components", new { Name = name, Field = field, Department = department, CreatedBy = user });
+            if (!resp.IsSuccessStatusCode) return null;
+            return await resp.Content.ReadFromJsonAsync<CustomComponent>();
+        }
+
+        public async Task Delete(int id, string user)
+        {
+            await _http.DeleteAsync($"api/components/{id}?user={Uri.EscapeDataString(user)}");
+        }
+    }
+}

--- a/NdaProcesses.Shared/Models/AppInfo.cs
+++ b/NdaProcesses.Shared/Models/AppInfo.cs
@@ -2,5 +2,5 @@ namespace DynamicFormsApp.Shared.Models;
 
 public static class AppInfo
 {
-public const string Version = "0.9.8";
+public const string Version = "0.9.16";
 }

--- a/NdaProcesses.Shared/Models/CustomComponent.cs
+++ b/NdaProcesses.Shared/Models/CustomComponent.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DynamicFormsApp.Shared;
+
+namespace DynamicFormsApp.Shared.Models
+{
+    public class CustomComponent
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string FieldJson { get; set; } = string.Empty;
+        public string CreatedBy { get; set; } = string.Empty;
+        public string Department { get; set; } = string.Empty;
+
+        [NotMapped]
+        [JsonIgnore]
+        public DesignerField? Field => string.IsNullOrWhiteSpace(FieldJson) ? null : JsonSerializer.Deserialize<DesignerField>(FieldJson);
+    }
+}

--- a/NdaProcesses.Shared/Models/StatusLabel.cs
+++ b/NdaProcesses.Shared/Models/StatusLabel.cs
@@ -1,0 +1,8 @@
+namespace DynamicFormsApp.Shared.Models
+{
+    public class StatusLabel
+    {
+        public string Label { get; set; } = string.Empty;
+        public string Icon { get; set; } = "🏷️";
+    }
+}

--- a/Server/Controllers/ComponentsController.cs
+++ b/Server/Controllers/ComponentsController.cs
@@ -1,0 +1,63 @@
+using DynamicFormsApp.Server.Services;
+using DynamicFormsApp.Shared;
+using DynamicFormsApp.Shared.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace DynamicFormsApp.Server.Controllers
+{
+    [ApiController]
+    [Route("api/components")]
+    public class ComponentsController : ControllerBase
+    {
+        private readonly ComponentService _service;
+        public ComponentsController(ComponentService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet("{department}")]
+        public async Task<IEnumerable<CustomComponent>> GetForUser(string department, [FromQuery] string user)
+        {
+            return await _service.GetForUserAsync(department, user);
+        }
+
+        public class SaveComponentRequest
+        {
+            public string Name { get; set; } = string.Empty;
+            public DesignerField Field { get; set; } = new();
+            public string Department { get; set; } = string.Empty;
+            public string CreatedBy { get; set; } = string.Empty;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<CustomComponent>> Save([FromBody] SaveComponentRequest req)
+        {
+            if (string.IsNullOrWhiteSpace(req.Name))
+                return BadRequest("Name is required");
+            if (RequiresOptions(req.Field.FieldType) && !HasOptions(req.Field))
+                return BadRequest("At least one option is required");
+            var comp = await _service.SaveAsync(req.Name, req.Field, req.Department, req.CreatedBy);
+            return Ok(comp);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id, [FromQuery] string user)
+        {
+            await _service.DeleteAsync(id, user);
+            return NoContent();
+        }
+        
+        private static bool RequiresOptions(string fieldType) =>
+            fieldType is "radio" or "checkbox" or "dropdown" or
+            "grid_radio" or "grid_checkbox" or "grid_text";
+
+        private static bool HasOptions(DesignerField field) => field.FieldType switch
+        {
+            "radio" or "checkbox" or "dropdown" => field.OptionItems.Any(o => !string.IsNullOrWhiteSpace(o)),
+            "grid_radio" or "grid_checkbox" => field.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) && field.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)),
+            "grid_text" => field.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)),
+            _ => true
+        };
+    }
+}

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -98,6 +98,22 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(row);
         }
 
+        public class StatusUpdate
+        {
+            public string Status { get; set; } = string.Empty;
+        }
+
+        [HttpPut("{id}/responses/{responseId}/status")]
+        public async Task<IActionResult> UpdateResponseStatus(int id, int responseId, [FromBody] StatusUpdate update)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+            await _svc.UpdateResponseStatusAsync(id, responseId, update.Status, user);
+            return NoContent();
+        }
+
 
         // GET /api/forms/{id}
         [HttpGet("{id}")]

--- a/Server/Data/AppDbContext.cs
+++ b/Server/Data/AppDbContext.cs
@@ -10,6 +10,7 @@ namespace DynamicFormsApp.Server.Data
         public DbSet<Form> Forms { get; set; }
         public DbSet<FormField> FormFields { get; set; }
         public DbSet<DynamicFormsApp.Shared.Models.FormShare> FormShares { get; set; }
+        public DbSet<CustomComponent> CustomComponents { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -6,6 +6,8 @@ using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Server.Data;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http;
+using System;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,6 +29,13 @@ builder.Services.AddDbContext<AppDbContext>(opts =>
 
 // Dynamic form service
 builder.Services.AddScoped<DynamicFormService>();
+builder.Services.AddScoped<ComponentService>();
+builder.Services.AddHttpClient<ComponentServiceProxy>((sp, client) =>
+{
+    var accessor = sp.GetRequiredService<IHttpContextAccessor>();
+    var request = accessor.HttpContext?.Request;
+    client.BaseAddress = new Uri($"{request?.Scheme}://{request?.Host}");
+});
 
 // CORS policy to allow any origin, method, and header
 builder.Services.AddCors(options =>

--- a/Server/Services/ComponentService.cs
+++ b/Server/Services/ComponentService.cs
@@ -1,0 +1,49 @@
+using DynamicFormsApp.Server.Data;
+using DynamicFormsApp.Shared;
+using DynamicFormsApp.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+using System.Linq;
+
+namespace DynamicFormsApp.Server.Services
+{
+    public class ComponentService
+    {
+        private readonly AppDbContext _db;
+        public ComponentService(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<CustomComponent> SaveAsync(string name, DesignerField field, string department, string user)
+        {
+            var comp = new CustomComponent
+            {
+                Name = name,
+                FieldJson = JsonSerializer.Serialize(field),
+                Department = department,
+                CreatedBy = user
+            };
+            _db.CustomComponents.Add(comp);
+            await _db.SaveChangesAsync();
+            return comp;
+        }
+
+        public async Task<List<CustomComponent>> GetForUserAsync(string department, string user)
+        {
+            return await _db.CustomComponents
+                .Where(c => c.Department == department || c.CreatedBy == user)
+                .ToListAsync();
+        }
+
+        public async Task DeleteAsync(int id, string user)
+        {
+            var comp = await _db.CustomComponents.FirstOrDefaultAsync(c => c.Id == id && c.CreatedBy == user);
+            if (comp != null)
+            {
+                _db.CustomComponents.Remove(comp);
+                await _db.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -102,7 +102,7 @@ namespace DynamicFormsApp.Server.Services
                 existing.Fields.Clear();
 
                 var newTable = $"Form_{existing.Id}_{rawName}";
-                var sb = new StringBuilder($"CREATE TABLE [{newTable}] (ResponseId INT IDENTITY(1,1) PRIMARY KEY, CreatedAt DATETIME2 NOT NULL");
+                var sb = new StringBuilder($"CREATE TABLE [{newTable}] (ResponseId INT IDENTITY(1,1) PRIMARY KEY, CreatedAt DATETIME2 NOT NULL, Status NVARCHAR(50) NOT NULL DEFAULT 'Pending'");
                 if (dto.RequireLogin)
                 {
                     sb.Append(", [ResponderName] NVARCHAR(255) NULL");
@@ -276,7 +276,8 @@ namespace DynamicFormsApp.Server.Services
             var sb = new StringBuilder(
                 $"CREATE TABLE [{tableName}] (" +
                 "ResponseId INT IDENTITY(1,1) PRIMARY KEY, " +
-                "CreatedAt DATETIME2 NOT NULL");
+                "CreatedAt DATETIME2 NOT NULL, " +
+                "Status NVARCHAR(50) NOT NULL DEFAULT 'Pending'");
             if (requireLogin)
             {
                 sb.Append(", [ResponderName] NVARCHAR(255) NULL");
@@ -357,9 +358,10 @@ namespace DynamicFormsApp.Server.Services
                 idx++;
             }
 
-            cols = string.IsNullOrEmpty(cols) ? "CreatedAt" : cols + ", CreatedAt";
-            paramNames = string.IsNullOrEmpty(paramNames) ? "@p_created" : paramNames + ", @p_created";
+            cols = string.IsNullOrEmpty(cols) ? "CreatedAt, Status" : cols + ", CreatedAt, Status";
+            paramNames = string.IsNullOrEmpty(paramNames) ? "@p_created, @p_status" : paramNames + ", @p_created, @p_status";
             sqlParams.Add(new SqlParameter("@p_created", DateTime.UtcNow));
+            sqlParams.Add(new SqlParameter("@p_status", "Pending"));
 
             if (form.RequireLogin)
             {
@@ -705,6 +707,35 @@ namespace DynamicFormsApp.Server.Services
             return ids;
         }
 
+        public async Task UpdateResponseStatusAsync(int formId, int responseId, string status, string user)
+        {
+            if (!await HasResponseAccessAsync(formId, user))
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var form = await _db.Forms.FindAsync(formId)
+                       ?? throw new InvalidOperationException("Form not found");
+            var rawName = SanitizeKey(form.Name);
+            var tableName = $"Form_{formId}_{rawName}";
+
+            using var conn = _db.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"UPDATE [{tableName}] SET Status=@status WHERE ResponseId=@id;";
+            var p1 = cmd.CreateParameter();
+            p1.ParameterName = "@status";
+            p1.Value = status ?? string.Empty;
+            cmd.Parameters.Add(p1);
+            var p2 = cmd.CreateParameter();
+            p2.ParameterName = "@id";
+            p2.Value = responseId;
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync();
+        }
+
         private string MapToSqlType(string fieldType) => fieldType switch
         {
             "number" => "FLOAT",
@@ -721,6 +752,7 @@ namespace DynamicFormsApp.Server.Services
             "textarea" => "NVARCHAR(MAX)",
             "grid_radio" => "NVARCHAR(MAX)",    // JSON object
             "grid_checkbox" => "NVARCHAR(MAX)", // JSON object
+            "grid_text" => "NVARCHAR(MAX)",     // JSON array of rows
             "scale" => "INT",
             _ => "NVARCHAR(MAX)"
         };

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -102,7 +102,7 @@ namespace DynamicFormsApp.Server.Services
                 existing.Fields.Clear();
 
                 var newTable = $"Form_{existing.Id}_{rawName}";
-                var sb = new StringBuilder($"CREATE TABLE [{newTable}] (ResponseId INT IDENTITY(1,1) PRIMARY KEY, CreatedAt DATETIME2 NOT NULL, Status NVARCHAR(50) NOT NULL DEFAULT 'Pending'");
+                var sb = new StringBuilder($"CREATE TABLE [{newTable}] (ResponseId INT IDENTITY(1,1) PRIMARY KEY, CreatedAt DATETIME2 NOT NULL, Status NVARCHAR(50) NULL");
                 if (dto.RequireLogin)
                 {
                     sb.Append(", [ResponderName] NVARCHAR(255) NULL");
@@ -277,7 +277,7 @@ namespace DynamicFormsApp.Server.Services
                 $"CREATE TABLE [{tableName}] (" +
                 "ResponseId INT IDENTITY(1,1) PRIMARY KEY, " +
                 "CreatedAt DATETIME2 NOT NULL, " +
-                "Status NVARCHAR(50) NOT NULL DEFAULT 'Pending'");
+                "Status NVARCHAR(50) NULL");
             if (requireLogin)
             {
                 sb.Append(", [ResponderName] NVARCHAR(255) NULL");
@@ -361,7 +361,7 @@ namespace DynamicFormsApp.Server.Services
             cols = string.IsNullOrEmpty(cols) ? "CreatedAt, Status" : cols + ", CreatedAt, Status";
             paramNames = string.IsNullOrEmpty(paramNames) ? "@p_created, @p_status" : paramNames + ", @p_created, @p_status";
             sqlParams.Add(new SqlParameter("@p_created", DateTime.UtcNow));
-            sqlParams.Add(new SqlParameter("@p_status", "Pending"));
+            sqlParams.Add(new SqlParameter("@p_status", DBNull.Value));
 
             if (form.RequireLogin)
             {

--- a/Server/Services/UserService.cs
+++ b/Server/Services/UserService.cs
@@ -138,10 +138,13 @@ namespace DynamicFormsApp.Server.Services
                 searcher.PropertiesToLoad.Add("sAMAccountName");
                 searcher.PropertiesToLoad.Add("displayName");
                 searcher.PropertiesToLoad.Add("mail");
+                searcher.PropertiesToLoad.Add("userAccountControl");
                 foreach (SearchResult result in searcher.FindAll())
                 {
                     if (result.Properties["sAMAccountName"].Count == 0) continue;
                     if (result.Properties["mail"].Count == 0) continue;
+                    var uac = result.Properties["userAccountControl"].Count > 0 ? result.Properties["userAccountControl"][0].ToString() : string.Empty;
+                    if (uac == "514" || uac == "66048") continue;
                     var user = new UserModel
                     {
                         UserName = result.Properties["sAMAccountName"][0].ToString()!,
@@ -251,10 +254,13 @@ namespace DynamicFormsApp.Server.Services
                 searcher.PropertiesToLoad.Add("sAMAccountName");
                 searcher.PropertiesToLoad.Add("displayName");
                 searcher.PropertiesToLoad.Add("mail");
+                searcher.PropertiesToLoad.Add("userAccountControl");
                 foreach (SearchResult result in searcher.FindAll())
                 {
                     if (result.Properties["sAMAccountName"].Count == 0) continue;
                     if (result.Properties["mail"].Count == 0) continue;
+                    var uac = result.Properties["userAccountControl"].Count > 0 ? result.Properties["userAccountControl"][0].ToString() : string.Empty;
+                    if (uac == "514" || uac == "66048") continue;
                     var user = new UserModel
                     {
                         UserName = result.Properties["sAMAccountName"][0].ToString()!,

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -8,6 +8,7 @@
     user-select: none;
     display: inline-flex;
     align-items: center;
+    position: relative;
     flex: 0 0 calc(50% - 0.5rem);
 }
 
@@ -18,6 +19,19 @@
 
     .draggable-field:hover {
         background-color: #e9ecef;
+    }
+
+    .toolbox-preview {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        background: #fff;
+        border: 1px solid #ccc;
+        padding: 4px;
+        z-index: 1000;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+        pointer-events: none;
     }
 
 /* 📋 Form canvas drop zone */

--- a/Server/wwwroot/js/dragdrop-wrapper.js
+++ b/Server/wwwroot/js/dragdrop-wrapper.js
@@ -88,3 +88,30 @@ window.focusLastInput = (container) => {
 window.triggerClick = (el) => {
     if (el) el.click();
 };
+
+window.initToolboxPreview = () => {
+    document.querySelectorAll('.draggable-field').forEach(el => {
+        if (el.dataset.previewInit === 'true') return;
+        el.dataset.previewInit = 'true';
+        const preview = el.querySelector('.toolbox-preview');
+        if (!preview) return;
+
+        const offset = 4;
+
+        el.addEventListener('mouseenter', e => {
+            document.body.appendChild(preview);
+            preview.style.display = 'block';
+            preview.style.top = (e.clientY + offset) + 'px';
+            preview.style.left = (e.clientX + offset) + 'px';
+        });
+
+        el.addEventListener('mousemove', e => {
+            preview.style.top = (e.clientY + offset) + 'px';
+            preview.style.left = (e.clientX + offset) + 'px';
+        });
+
+        el.addEventListener('mouseleave', () => {
+            preview.style.display = 'none';
+        });
+    });
+};


### PR DESCRIPTION
## Summary
- move saved component list to toolbox bottom and show field-specific icons
- allow saving components for just yourself or share department-wide
- track and edit response statuses like Approved or Pending

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a878187df88329818e4cef9b1a01e2